### PR TITLE
feat: add mission package writer and local storage

### DIFF
--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -21,10 +21,14 @@ import com.cachekid.companion.host.importing.MissionDraftFactory
 import com.cachekid.companion.host.importing.SharedCacheImportResult
 import com.cachekid.companion.host.importing.SharedTextPayload
 import com.cachekid.companion.host.mission.MissionDraft
+import com.cachekid.companion.host.mission.MissionPackageFileStore
+import com.cachekid.companion.host.mission.MissionPackageStoreResult
+import com.cachekid.companion.host.mission.MissionPackageWriter
 import com.cachekid.companion.host.resolution.CacheResolutionResult
 import com.cachekid.companion.host.resolution.HostCacheResolver
 import com.cachekid.companion.host.resolution.ManualCacheResolutionService
 import com.cachekid.companion.web.NativeBridge
+import java.io.File
 
 class MainActivity : AppCompatActivity() {
 
@@ -35,11 +39,14 @@ class MainActivity : AppCompatActivity() {
     private val hostCacheResolver = HostCacheResolver()
     private val manualCacheResolutionService = ManualCacheResolutionService()
     private val missionDraftFactory = MissionDraftFactory()
+    private val missionPackageWriter = MissionPackageWriter()
+    private val missionPackageFileStore = MissionPackageFileStore()
 
     private var pendingImportResult: SharedCacheImportResult? = null
     private var pendingResolutionResult: CacheResolutionResult? = null
     private var pendingMissionDraft: MissionDraft? = null
     private var pendingShareDebug: String? = null
+    private var storedMissionResult: MissionPackageStoreResult? = null
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
@@ -88,6 +95,22 @@ class MainActivity : AppCompatActivity() {
                 Toast.makeText(
                     this,
                     "Mission erstellt.",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
+        binding.nativeSaveMissionButton.setOnClickListener {
+            val result = storePendingMissionDraft()
+            if (result?.isSuccess == true) {
+                Toast.makeText(
+                    this,
+                    "Mission lokal gespeichert.",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            } else {
+                Toast.makeText(
+                    this,
+                    result?.errors?.firstOrNull() ?: "Mission konnte nicht gespeichert werden.",
                     Toast.LENGTH_SHORT,
                 ).show()
             }
@@ -202,6 +225,7 @@ class MainActivity : AppCompatActivity() {
         pendingImportResult = hostShareImportService.importFrom(payload)
         pendingResolutionResult = pendingImportResult?.value?.let { hostCacheResolver.resolve(it) }
         pendingMissionDraft = pendingResolutionResult?.value?.let { missionDraftFactory.createFrom(it) }
+        storedMissionResult = null
         refreshNativeImportPanel()
         if (::nativeBridge.isInitialized) {
             nativeBridge.notifyImportUpdated()
@@ -228,12 +252,19 @@ class MainActivity : AppCompatActivity() {
         val needsManualResolution =
             pendingMissionDraft == null &&
                 pendingResolutionResult?.status == com.cachekid.companion.host.resolution.CacheResolutionStatus.NEEDS_ONLINE_RESOLUTION
+        val hasDraftReadyMission = pendingMissionDraft != null
 
         binding.nativeImportDebug.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
         binding.nativeImportDebug.text = if (needsManualResolution) debug.orEmpty() else ""
         binding.nativeResolutionTitleInput.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
         binding.nativeResolutionTargetInput.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
         binding.nativeResolveButton.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
+        binding.nativeSaveMissionButton.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
+        binding.nativeStoredMissionStatus.visibility =
+            if (hasDraftReadyMission && storedMissionResult?.isSuccess == true) View.VISIBLE else View.GONE
+        binding.nativeStoredMissionStatus.text = storedMissionResult?.missionDirectory?.let { missionDirectory ->
+            "Gespeichert in: ${missionDirectory.name}"
+        }.orEmpty()
 
         if (needsManualResolution && binding.nativeResolutionTitleInput.text.isNullOrBlank()) {
             binding.nativeResolutionTitleInput.setText(pendingResolutionResult?.cacheCodeHint.orEmpty())
@@ -244,6 +275,10 @@ class MainActivity : AppCompatActivity() {
         if (!needsManualResolution) {
             binding.nativeResolutionTitleInput.text?.clear()
             binding.nativeResolutionTargetInput.text?.clear()
+        }
+        if (!hasDraftReadyMission) {
+            storedMissionResult = null
+            binding.nativeStoredMissionStatus.text = ""
         }
     }
 
@@ -331,6 +366,7 @@ class MainActivity : AppCompatActivity() {
             messages = listOf("Cache manuell vervollstaendigt."),
         )
         pendingMissionDraft = missionDraftFactory.createFrom(resolvedCache)
+        storedMissionResult = null
         refreshNativeImportPanel()
         if (::nativeBridge.isInitialized) {
             nativeBridge.notifyImportUpdated()
@@ -338,7 +374,28 @@ class MainActivity : AppCompatActivity() {
         return pendingMissionDraft
     }
 
+    private fun storePendingMissionDraft(): MissionPackageStoreResult? {
+        val draft = pendingMissionDraft ?: return null
+        val writeResult = missionPackageWriter.write(draft)
+        if (!writeResult.isSuccess) {
+            return MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = writeResult.errors,
+            )
+        }
+
+        val missionPackage = writeResult.missionPackage ?: return null
+        val missionsDirectory = File(filesDir, MISSION_STORAGE_DIRECTORY)
+        storedMissionResult = missionPackageFileStore.store(
+            baseDirectory = missionsDirectory,
+            missionPackage = missionPackage,
+        )
+        refreshNativeImportPanel()
+        return storedMissionResult
+    }
+
     private companion object {
         const val DEFAULT_TARGET_TEXT = "52.520008,13.404954"
+        const val MISSION_STORAGE_DIRECTORY = "missions"
     }
 }

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackage.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackage.kt
@@ -1,0 +1,7 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackage(
+    val missionId: String,
+    val manifest: MissionManifest,
+    val files: List<MissionPackageFile>,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageFile.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageFile.kt
@@ -1,0 +1,6 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackageFile(
+    val path: String,
+    val content: String,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageFileStore.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageFileStore.kt
@@ -1,0 +1,51 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+class MissionPackageFileStore {
+
+    fun store(baseDirectory: File, missionPackage: MissionPackage): MissionPackageStoreResult {
+        val expectedFiles = MissionPackageSchema.requiredManifestFiles.toSet()
+        val actualFiles = missionPackage.files.map { it.path }.toSet()
+        val missingFiles = expectedFiles - actualFiles
+        if (missingFiles.isNotEmpty()) {
+            return MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = listOf("Mission package is missing required files: ${missingFiles.sorted().joinToString(", ")}"),
+            )
+        }
+
+        if (baseDirectory.exists() && !baseDirectory.isDirectory) {
+            return MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = listOf("Base mission storage path is not a directory."),
+            )
+        }
+
+        if (!baseDirectory.exists() && !baseDirectory.mkdirs()) {
+            return MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = listOf("Base mission storage directory could not be created."),
+            )
+        }
+
+        val missionDirectory = File(baseDirectory, missionPackage.missionId)
+        if (!missionDirectory.exists() && !missionDirectory.mkdirs()) {
+            return MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = listOf("Mission directory could not be created."),
+            )
+        }
+
+        missionPackage.files.forEach { packageFile ->
+            val outputFile = File(missionDirectory, packageFile.path)
+            outputFile.parentFile?.mkdirs()
+            outputFile.writeText(packageFile.content)
+        }
+
+        return MissionPackageStoreResult(
+            missionDirectory = missionDirectory,
+            errors = emptyList(),
+        )
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSchema.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSchema.kt
@@ -4,6 +4,7 @@ object MissionPackageSchema {
     const val CURRENT_SCHEMA_VERSION: Int = 1
 
     val requiredManifestFiles: List<String> = listOf(
+        "integrity.json",
         "manifest.json",
         "mission.json",
     )

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageStoreResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageStoreResult.kt
@@ -1,0 +1,11 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+data class MissionPackageStoreResult(
+    val missionDirectory: File?,
+    val errors: List<String>,
+) {
+    val isSuccess: Boolean
+        get() = missionDirectory != null && errors.isEmpty()
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageWriteResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageWriteResult.kt
@@ -1,0 +1,9 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackageWriteResult(
+    val missionPackage: MissionPackage?,
+    val errors: List<String>,
+) {
+    val isSuccess: Boolean
+        get() = missionPackage != null && errors.isEmpty()
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageWriter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageWriter.kt
@@ -1,0 +1,111 @@
+package com.cachekid.companion.host.mission
+
+import java.security.MessageDigest
+import java.util.Locale
+
+class MissionPackageWriter(
+    private val validator: MissionDraftValidator = MissionDraftValidator(),
+) {
+
+    fun write(draft: MissionDraft): MissionPackageWriteResult {
+        val validation = validator.validate(draft)
+        if (!validation.isValid) {
+            return MissionPackageWriteResult(
+                missionPackage = null,
+                errors = validation.errors,
+            )
+        }
+
+        val missionId = buildMissionId(draft)
+        val missionJson = buildMissionJson(draft, missionId)
+        val missionSha256 = sha256Hex(missionJson)
+        val integrityJson = buildIntegrityJson(missionSha256)
+        val manifest = MissionManifest(
+            schemaVersion = MissionPackageSchema.CURRENT_SCHEMA_VERSION,
+            missionId = missionId,
+            files = MissionPackageSchema.requiredManifestFiles,
+        )
+        val manifestJson = buildManifestJson(manifest)
+
+        val files = listOf(
+            MissionPackageFile(path = "integrity.json", content = integrityJson),
+            MissionPackageFile(path = "manifest.json", content = manifestJson),
+            MissionPackageFile(path = "mission.json", content = missionJson),
+        ).sortedBy { it.path }
+
+        return MissionPackageWriteResult(
+            missionPackage = MissionPackage(
+                missionId = missionId,
+                manifest = manifest,
+                files = files,
+            ),
+            errors = emptyList(),
+        )
+    }
+
+    private fun buildMissionId(draft: MissionDraft): String {
+        val normalizedTitle = draft.childTitle
+            .trim()
+            .lowercase(Locale.ROOT)
+            .replace(Regex("""[^a-z0-9]+"""), "-")
+            .trim('-')
+            .ifBlank { "mission" }
+
+        return "${draft.cacheCode.lowercase(Locale.ROOT)}-$normalizedTitle"
+    }
+
+    private fun buildMissionJson(draft: MissionDraft, missionId: String): String {
+        val escapedSourceApp = draft.sourceApp?.let { "\"${escapeJson(it)}\"" } ?: "null"
+        return """
+            {
+              "schemaVersion": ${MissionPackageSchema.CURRENT_SCHEMA_VERSION},
+              "missionId": "${escapeJson(missionId)}",
+              "cacheCode": "${escapeJson(draft.cacheCode)}",
+              "sourceTitle": "${escapeJson(draft.sourceTitle)}",
+              "childTitle": "${escapeJson(draft.childTitle)}",
+              "summary": "${escapeJson(draft.summary)}",
+              "target": {
+                "latitude": ${draft.target.latitude},
+                "longitude": ${draft.target.longitude}
+              },
+              "sourceApp": $escapedSourceApp
+            }
+        """.trimIndent()
+    }
+
+    private fun buildManifestJson(manifest: MissionManifest): String {
+        val filesJson = manifest.files.joinToString(",\n") { file ->
+            """    "${escapeJson(file)}""""
+        }
+        return """
+            {
+              "schemaVersion": ${manifest.schemaVersion},
+              "missionId": "${escapeJson(manifest.missionId)}",
+              "files": [
+$filesJson
+              ]
+            }
+        """.trimIndent()
+    }
+
+    private fun buildIntegrityJson(missionSha256: String): String {
+        return """
+            {
+              "algorithm": "sha256",
+              "missionJsonSha256": "$missionSha256"
+            }
+        """.trimIndent()
+    }
+
+    private fun sha256Hex(content: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { byte -> "%02x".format(byte) }
+    }
+
+    private fun escapeJson(value: String): String {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -71,6 +71,23 @@
             android:layout_marginTop="10dp"
             android:text="Mission manuell anlegen"
             android:visibility="gone" />
+
+        <Button
+            android:id="@+id/nativeSaveMissionButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Mission lokal speichern"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/nativeStoredMissionStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="#5D5D55"
+            android:textSize="12sp"
+            android:visibility="gone" />
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageFileStoreTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageFileStoreTest.kt
@@ -1,0 +1,66 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class MissionPackageFileStoreTest {
+
+    private val writer = MissionPackageWriter()
+    private val store = MissionPackageFileStore()
+
+    @Test
+    fun `store writes mission package into deterministic mission directory`() {
+        val tempDir = createTempDirectory("cachekid-mission-store").toFile()
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+
+        val result = store.store(tempDir, missionPackage)
+
+        assertTrue(result.isSuccess)
+        val missionDirectory = requireNotNull(result.missionDirectory)
+        assertEquals(missionPackage.missionId, missionDirectory.name)
+        assertTrue(File(missionDirectory, "manifest.json").exists())
+        assertTrue(File(missionDirectory, "mission.json").exists())
+        assertTrue(File(missionDirectory, "integrity.json").exists())
+    }
+
+    @Test
+    fun `store rejects mission package with missing required files`() {
+        val tempDir = createTempDirectory("cachekid-mission-store-invalid").toFile()
+        val invalidPackage = MissionPackage(
+            missionId = "gc12345-test",
+            manifest = MissionManifest(
+                schemaVersion = MissionPackageSchema.CURRENT_SCHEMA_VERSION,
+                missionId = "gc12345-test",
+                files = MissionPackageSchema.requiredManifestFiles,
+            ),
+            files = listOf(
+                MissionPackageFile("mission.json", "{}"),
+            ),
+        )
+
+        val result = store.store(tempDir, invalidPackage)
+
+        assertFalse(result.isSuccess)
+        assertEquals(null, result.missionDirectory)
+        assertNotNull(result.errors.firstOrNull())
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(
+                latitude = 52.520008,
+                longitude = 13.404954,
+            ),
+            sourceApp = "geocaching",
+        )
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageWriterTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageWriterTest.kt
@@ -1,0 +1,74 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MissionPackageWriterTest {
+
+    private val writer = MissionPackageWriter()
+
+    @Test
+    fun `writer produces deterministic mission package layout`() {
+        val draft = validDraft()
+
+        val first = writer.write(draft)
+        val second = writer.write(draft)
+
+        assertTrue(first.isSuccess)
+        assertTrue(second.isSuccess)
+        assertEquals(first.missionPackage, second.missionPackage)
+        assertEquals(
+            listOf("integrity.json", "manifest.json", "mission.json"),
+            first.missionPackage?.files?.map { it.path },
+        )
+    }
+
+    @Test
+    fun `writer includes integrity checksum for mission json`() {
+        val result = writer.write(validDraft())
+
+        val missionPackage = requireNotNull(result.missionPackage)
+        val integrityFile = missionPackage.files.firstOrNull { it.path == "integrity.json" }
+        val missionFile = missionPackage.files.firstOrNull { it.path == "mission.json" }
+
+        assertNotNull(integrityFile)
+        assertNotNull(missionFile)
+        assertTrue(integrityFile!!.content.contains("\"algorithm\": \"sha256\""))
+        assertTrue(integrityFile.content.contains("missionJsonSha256"))
+        assertTrue(missionFile!!.content.contains("\"missionId\": \"gc12345-der-schatz-im-wald\""))
+    }
+
+    @Test
+    fun `writer returns validation errors for invalid draft`() {
+        val result = writer.write(
+            MissionDraft(
+                cacheCode = "",
+                sourceTitle = "",
+                childTitle = "",
+                summary = "",
+                target = MissionTarget(999.0, 999.0),
+            ),
+        )
+
+        assertFalse(result.isSuccess)
+        assertEquals(null, result.missionPackage)
+        assertTrue(result.errors.isNotEmpty())
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(
+                latitude = 52.520008,
+                longitude = 13.404954,
+            ),
+            sourceApp = "geocaching",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add the host-side MissionPackage writer and deterministic package model
- add integrity.json checksum output alongside manifest.json and mission.json
- add a host-side file store that persists one mission package into local mission storage
- wire the existing parent host flow so a draft-ready mission can be saved locally from the app UI

## Issue

Closes #7

## Validation

- [x] frontend-tests
- [x] Android Studio unit tests for MissionPackageWriterTest and MissionPackageFileStoreTest
- [x] Added or updated automated tests
- [x] Manual verification noted where automation is not yet possible

## Manual verification

- created a draft-ready mission in the emulator
- saved the mission locally from the native host panel
- confirmed the saved-state message in the host UI

## Architecture

- keeps package writing and package storage in testable host mission classes
- keeps MainActivity limited to orchestration and user actions
- does not yet add receiver, transfer, or Meebook import behavior

## Risk

- User-facing risk: local package storage exists, but no transfer path is implemented in this branch
- Rollback path: revert this PR to remove local package writing and return to draft-only host flow
