### PR TITLE
feat: add local mission package receiver flow

### DIFF
--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -22,6 +22,7 @@ import com.cachekid.companion.host.importing.SharedCacheImportResult
 import com.cachekid.companion.host.importing.SharedTextPayload
 import com.cachekid.companion.host.mission.MissionDraft
 import com.cachekid.companion.host.mission.MissionPackageFileStore
+import com.cachekid.companion.host.mission.MissionPackageReceiverServer
 import com.cachekid.companion.host.mission.MissionPackageStoreResult
 import com.cachekid.companion.host.mission.MissionPackageWriter
 import com.cachekid.companion.host.resolution.CacheResolutionResult
@@ -47,6 +48,9 @@ class MainActivity : AppCompatActivity() {
     private var pendingMissionDraft: MissionDraft? = null
     private var pendingShareDebug: String? = null
     private var storedMissionResult: MissionPackageStoreResult? = null
+    private var receiveServer: MissionPackageReceiverServer? = null
+    private var receiveServerRunning: Boolean = false
+    private var receiveStatusText: String = "Empfang aus."
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions(),
@@ -115,9 +119,13 @@ class MainActivity : AppCompatActivity() {
                 ).show()
             }
         }
+        binding.nativeReceiveToggleButton.setOnClickListener {
+            toggleReceiveMode()
+        }
 
         handleShareIntent(intent)
         refreshNativeImportPanel()
+        refreshReceivePanel()
         configureWebView(binding.webView)
         binding.webView.loadUrl("file:///android_asset/web/index.html")
     }
@@ -142,6 +150,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        receiveServer?.stop()
         binding.webView.apply {
             removeJavascriptInterface("AndroidHost")
             stopLoading()
@@ -282,6 +291,15 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun refreshReceivePanel() {
+        binding.nativeReceiveStatus.text = receiveStatusText
+        binding.nativeReceiveToggleButton.text = if (receiveServerRunning) {
+            "Empfang stoppen"
+        } else {
+            "Empfang starten"
+        }
+    }
+
     private fun extractSharedText(intent: android.content.Intent): String? {
         val parts = linkedSetOf<String>()
 
@@ -392,6 +410,32 @@ class MainActivity : AppCompatActivity() {
         )
         refreshNativeImportPanel()
         return storedMissionResult
+    }
+
+    private fun toggleReceiveMode() {
+        if (receiveServerRunning) {
+            receiveServer?.stop()
+            receiveServer = null
+            receiveServerRunning = false
+            receiveStatusText = "Empfang aus."
+            refreshReceivePanel()
+            return
+        }
+
+        val server = MissionPackageReceiverServer(
+            baseDirectory = File(filesDir, MISSION_STORAGE_DIRECTORY),
+            onStatusChanged = { status ->
+                runOnUiThread {
+                    receiveStatusText = status
+                    refreshReceivePanel()
+                }
+            },
+        )
+        val port = server.start()
+        receiveServer = server
+        receiveServerRunning = true
+        receiveStatusText = "Empfang aktiv auf Port $port."
+        refreshReceivePanel()
     }
 
     private companion object {

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageImportResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageImportResult.kt
@@ -1,0 +1,12 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+data class MissionPackageImportResult(
+    val missionDirectory: File?,
+    val missionId: String?,
+    val errors: List<String>,
+) {
+    val isSuccess: Boolean
+        get() = missionDirectory != null && missionId != null && errors.isEmpty()
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReader.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReader.kt
@@ -1,0 +1,41 @@
+package com.cachekid.companion.host.mission
+
+class MissionPackageReader {
+
+    fun read(files: Map<String, String>): MissionPackage? {
+        val manifestJson = files["manifest.json"] ?: return null
+        val missionId = extractStringValue(manifestJson, "missionId") ?: return null
+        val schemaVersion = extractIntValue(manifestJson, "schemaVersion") ?: return null
+        val manifestFiles = extractStringArray(manifestJson, "files")
+
+        val manifest = MissionManifest(
+            schemaVersion = schemaVersion,
+            missionId = missionId,
+            files = manifestFiles,
+        )
+
+        return MissionPackage(
+            missionId = missionId,
+            manifest = manifest,
+            files = files.toSortedMap().map { (path, content) ->
+                MissionPackageFile(path = path, content = content)
+            },
+        )
+    }
+
+    private fun extractStringValue(json: String, key: String): String? {
+        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
+        return regex.find(json)?.groupValues?.getOrNull(1)
+    }
+
+    private fun extractIntValue(json: String, key: String): Int? {
+        val regex = Regex(""""$key"\s*:\s*(\d+)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun extractStringArray(json: String, key: String): List<String> {
+        val regex = Regex(""""$key"\s*:\s*\[(.*?)]""", RegexOption.DOT_MATCHES_ALL)
+        val body = regex.find(json)?.groupValues?.getOrNull(1) ?: return emptyList()
+        return Regex(""""([^"]+)"""").findAll(body).map { it.groupValues[1] }.toList()
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverServer.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverServer.kt
@@ -1,0 +1,137 @@
+package com.cachekid.companion.host.mission
+
+import java.io.BufferedInputStream
+import java.io.File
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+
+class MissionPackageReceiverServer(
+    private val baseDirectory: File,
+    private val importer: MissionPackageZipImporter = MissionPackageZipImporter(),
+    private val port: Int = DEFAULT_PORT,
+    private val onStatusChanged: (String) -> Unit,
+) {
+
+    private val running = AtomicBoolean(false)
+    private var executor: ExecutorService? = null
+    private var serverSocket: ServerSocket? = null
+
+    fun start(): Int {
+        if (running.get()) {
+            return serverSocket?.localPort ?: port
+        }
+
+        val socket = ServerSocket(port)
+        executor = Executors.newSingleThreadExecutor()
+        serverSocket = socket
+        running.set(true)
+        onStatusChanged("Empfang aktiv auf Port ${socket.localPort}.")
+        executor?.execute {
+            runLoop(socket)
+        }
+        return socket.localPort
+    }
+
+    fun stop() {
+        running.set(false)
+        serverSocket?.close()
+        serverSocket = null
+        executor?.shutdownNow()
+        executor = null
+        onStatusChanged("Empfang gestoppt.")
+    }
+
+    private fun runLoop(socket: ServerSocket) {
+        while (running.get()) {
+            try {
+                val client = socket.accept()
+                client.use { handleClient(it) }
+            } catch (_: SocketException) {
+                if (!running.get()) {
+                    return
+                }
+            }
+        }
+    }
+
+    private fun handleClient(socket: Socket) {
+        val input = BufferedInputStream(socket.getInputStream())
+        val output = socket.getOutputStream()
+        val headersText = readHeaders(input)
+        val requestLine = headersText.lineSequence().firstOrNull().orEmpty()
+        val requestParts = requestLine.split(" ")
+        val method = requestParts.getOrNull(0)
+        val path = requestParts.getOrNull(1)
+        val contentLength = Regex("""Content-Length:\s*(\d+)""", RegexOption.IGNORE_CASE)
+            .find(headersText)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toIntOrNull()
+            ?: 0
+
+        if (method != "POST" || path != "/missions") {
+            writeResponse(output, 404, "Unsupported endpoint.")
+            return
+        }
+
+        val body = ByteArray(contentLength)
+        var bytesRead = 0
+        while (bytesRead < contentLength) {
+            val read = input.read(body, bytesRead, contentLength - bytesRead)
+            if (read <= 0) break
+            bytesRead += read
+        }
+
+        val result = importer.import(baseDirectory, body)
+        if (result.isSuccess) {
+            onStatusChanged("Mission empfangen: ${result.missionId}")
+            writeResponse(output, 200, "Stored ${result.missionId}")
+        } else {
+            onStatusChanged(result.errors.firstOrNull() ?: "Mission-Empfang fehlgeschlagen.")
+            writeResponse(output, 400, result.errors.joinToString(" "))
+        }
+    }
+
+    private fun readHeaders(input: BufferedInputStream): String {
+        val headerBytes = mutableListOf<Byte>()
+        while (true) {
+            val next = input.read()
+            if (next == -1) break
+            headerBytes.add(next.toByte())
+            if (headerBytes.size >= 4) {
+                val end = headerBytes.takeLast(4)
+                if (end[0] == '\r'.code.toByte() &&
+                    end[1] == '\n'.code.toByte() &&
+                    end[2] == '\r'.code.toByte() &&
+                    end[3] == '\n'.code.toByte()
+                ) {
+                    break
+                }
+            }
+        }
+        return headerBytes.toByteArray().toString(Charsets.UTF_8)
+    }
+
+    private fun writeResponse(output: java.io.OutputStream, statusCode: Int, body: String) {
+        val statusText = if (statusCode == 200) "OK" else "Bad Request"
+        val payload = body.toByteArray(Charsets.UTF_8)
+        output.write(
+            (
+                "HTTP/1.1 $statusCode $statusText\r\n" +
+                    "Content-Type: text/plain; charset=utf-8\r\n" +
+                    "Content-Length: ${payload.size}\r\n" +
+                    "Connection: close\r\n\r\n"
+                ).toByteArray(Charsets.UTF_8),
+        )
+        output.write(payload)
+        output.flush()
+    }
+
+    private companion object {
+        const val DEFAULT_PORT = 8765
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageValidationResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageValidationResult.kt
@@ -1,0 +1,6 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackageValidationResult(
+    val isValid: Boolean,
+    val errors: List<String>,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageValidator.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageValidator.kt
@@ -1,0 +1,70 @@
+package com.cachekid.companion.host.mission
+
+import java.security.MessageDigest
+
+class MissionPackageValidator {
+
+    fun validate(missionPackage: MissionPackage): MissionPackageValidationResult {
+        val errors = buildList {
+            val paths = missionPackage.files.map { it.path }.toSet()
+            val missing = MissionPackageSchema.requiredManifestFiles.toSet() - paths
+            if (missing.isNotEmpty()) {
+                add("Mission package is missing required files: ${missing.sorted().joinToString(", ")}")
+            }
+
+            val manifestFile = missionPackage.files.firstOrNull { it.path == "manifest.json" }
+            val integrityFile = missionPackage.files.firstOrNull { it.path == "integrity.json" }
+            val missionFile = missionPackage.files.firstOrNull { it.path == "mission.json" }
+
+            if (manifestFile != null) {
+                val manifestMissionId = extractStringValue(manifestFile.content, "missionId")
+                val manifestSchemaVersion = extractIntValue(manifestFile.content, "schemaVersion")
+                val manifestFileNames = extractStringArray(manifestFile.content, "files")
+
+                if (manifestMissionId != missionPackage.missionId) {
+                    add("Manifest missionId does not match package missionId.")
+                }
+                if (manifestSchemaVersion != MissionPackageSchema.CURRENT_SCHEMA_VERSION) {
+                    add("Manifest schemaVersion is not supported.")
+                }
+                if (manifestFileNames.toSet() != MissionPackageSchema.requiredManifestFiles.toSet()) {
+                    add("Manifest file list does not match the required mission package layout.")
+                }
+            }
+
+            if (integrityFile != null && missionFile != null) {
+                val expectedSha = extractStringValue(integrityFile.content, "missionJsonSha256")
+                val actualSha = sha256Hex(missionFile.content)
+                if (expectedSha != actualSha) {
+                    add("Integrity checksum does not match mission.json.")
+                }
+            }
+        }
+
+        return MissionPackageValidationResult(
+            isValid = errors.isEmpty(),
+            errors = errors,
+        )
+    }
+
+    private fun extractStringValue(json: String, key: String): String? {
+        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
+        return regex.find(json)?.groupValues?.getOrNull(1)
+    }
+
+    private fun extractIntValue(json: String, key: String): Int? {
+        val regex = Regex(""""$key"\s*:\s*(\d+)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun extractStringArray(json: String, key: String): List<String> {
+        val regex = Regex(""""$key"\s*:\s*\[(.*?)]""", RegexOption.DOT_MATCHES_ALL)
+        val body = regex.find(json)?.groupValues?.getOrNull(1) ?: return emptyList()
+        return Regex(""""([^"]+)"""").findAll(body).map { it.groupValues[1] }.toList()
+    }
+
+    private fun sha256Hex(content: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(content.toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { byte -> "%02x".format(byte) }
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipCodec.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipCodec.kt
@@ -1,0 +1,37 @@
+package com.cachekid.companion.host.mission
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+class MissionPackageZipCodec {
+
+    fun encode(missionPackage: MissionPackage): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zipOutput ->
+            missionPackage.files.sortedBy { it.path }.forEach { packageFile ->
+                zipOutput.putNextEntry(ZipEntry(packageFile.path))
+                zipOutput.write(packageFile.content.toByteArray(Charsets.UTF_8))
+                zipOutput.closeEntry()
+            }
+        }
+        return output.toByteArray()
+    }
+
+    fun decode(zipBytes: ByteArray): Map<String, String> {
+        val files = linkedMapOf<String, String>()
+        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zipInput ->
+            var entry = zipInput.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory) {
+                    files[entry.name] = zipInput.readBytes().toString(Charsets.UTF_8)
+                }
+                zipInput.closeEntry()
+                entry = zipInput.nextEntry
+            }
+        }
+        return files.toSortedMap()
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipImporter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipImporter.kt
@@ -1,0 +1,43 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+class MissionPackageZipImporter(
+    private val zipCodec: MissionPackageZipCodec = MissionPackageZipCodec(),
+    private val reader: MissionPackageReader = MissionPackageReader(),
+    private val validator: MissionPackageValidator = MissionPackageValidator(),
+    private val fileStore: MissionPackageFileStore = MissionPackageFileStore(),
+) {
+
+    fun import(baseDirectory: File, zipBytes: ByteArray): MissionPackageImportResult {
+        val files = runCatching { zipCodec.decode(zipBytes) }.getOrElse {
+            return MissionPackageImportResult(
+                missionDirectory = null,
+                missionId = null,
+                errors = listOf("Mission package ZIP could not be decoded."),
+            )
+        }
+
+        val missionPackage = reader.read(files) ?: return MissionPackageImportResult(
+            missionDirectory = null,
+            missionId = null,
+            errors = listOf("Mission package manifest is missing or invalid."),
+        )
+
+        val validation = validator.validate(missionPackage)
+        if (!validation.isValid) {
+            return MissionPackageImportResult(
+                missionDirectory = null,
+                missionId = missionPackage.missionId,
+                errors = validation.errors,
+            )
+        }
+
+        val storeResult = fileStore.store(baseDirectory, missionPackage)
+        return MissionPackageImportResult(
+            missionDirectory = storeResult.missionDirectory,
+            missionId = missionPackage.missionId,
+            errors = storeResult.errors,
+        )
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -90,4 +90,41 @@
             android:visibility="gone" />
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/nativeReceivePanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_margin="12dp"
+        android:background="#FFFDF8"
+        android:elevation="8dp"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/nativeReceiveTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Empfangsmodus"
+            android:textColor="#151515"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/nativeReceiveStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="Empfang aus."
+            android:textColor="#5D5D55"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/nativeReceiveToggleButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Empfang starten" />
+    </LinearLayout>
+
 </FrameLayout>

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverServerTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverServerTest.kt
@@ -1,0 +1,69 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.net.Socket
+import kotlin.io.path.createTempDirectory
+
+class MissionPackageReceiverServerTest {
+
+    private val writer = MissionPackageWriter()
+    private val zipCodec = MissionPackageZipCodec()
+
+    @Test
+    fun `receiver server accepts mission package upload over local http`() {
+        val statusMessages = mutableListOf<String>()
+        val tempDir = createTempDirectory("cachekid-receiver").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = { statusMessages.add(it) },
+        )
+        val port = server.start()
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val zipBytes = zipCodec.encode(missionPackage)
+            val response = sendHttpPost(port, zipBytes)
+
+            assertTrue(response.contains("200 OK"))
+            assertTrue(response.contains("Stored ${missionPackage.missionId}"))
+            assertTrue(statusMessages.any { it.contains("Mission empfangen") })
+        } finally {
+            server.stop()
+        }
+    }
+
+    private fun sendHttpPost(port: Int, body: ByteArray): String {
+        Socket("127.0.0.1", port).use { socket ->
+            val output = socket.getOutputStream()
+            output.write(
+                (
+                    "POST /missions HTTP/1.1\r\n" +
+                        "Host: 127.0.0.1\r\n" +
+                        "Content-Type: application/zip\r\n" +
+                        "Content-Length: ${body.size}\r\n" +
+                        "Connection: close\r\n\r\n"
+                    ).toByteArray(Charsets.UTF_8),
+            )
+            output.write(body)
+            output.flush()
+
+            val response = ByteArrayOutputStream()
+            socket.getInputStream().copyTo(response)
+            return response.toString(Charsets.UTF_8.name())
+        }
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(52.520008, 13.404954),
+            sourceApp = "geocaching",
+        )
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageZipImporterTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageZipImporterTest.kt
@@ -1,0 +1,39 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Files
+import kotlin.io.path.createTempDirectory
+
+class MissionPackageZipImporterTest {
+
+    private val writer = MissionPackageWriter()
+    private val zipCodec = MissionPackageZipCodec()
+    private val importer = MissionPackageZipImporter()
+
+    @Test
+    fun `zip importer decodes validates and stores a mission package`() {
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+        val zipBytes = zipCodec.encode(missionPackage)
+        val tempDir = createTempDirectory("cachekid-importer").toFile()
+
+        val result = importer.import(tempDir, zipBytes)
+        val missionDirectory = requireNotNull(result.missionDirectory)
+
+        assertTrue(result.isSuccess)
+        assertTrue(Files.exists(missionDirectory.toPath().resolve("mission.json")))
+        assertTrue(Files.exists(missionDirectory.toPath().resolve("manifest.json")))
+        assertTrue(Files.exists(missionDirectory.toPath().resolve("integrity.json")))
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(52.520008, 13.404954),
+            sourceApp = "geocaching",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add the kid-side local mission receiver flow and receive-mode UI
- add ZIP decoding, mission package reading, and package validation
- add a local HTTP receiver endpoint for uploaded mission packages
- persist received packages into local mission storage on successful import

## Issue

Closes #6

## Validation

- [x] Android Studio unit tests for MissionPackageZipImporterTest and MissionPackageReceiverServerTest
- [x] Added or updated automated tests
- [x] Manual verification noted where automation is not yet possible

## Manual verification

- enabled receive mode in the app UI
- confirmed the local receiver status is shown in the host panel
- verified the import and receiver tests pass in Android Studio

## Architecture

- keeps ZIP decoding, reading, validation, and storage in separate testable classes
- keeps MainActivity responsible for simple receive-mode orchestration only
- does not yet implement the sender-side transfer flow in this branch

## Risk

- User-facing risk: receive mode is local and low-level for now, without polished sender pairing UX
- Rollback path: revert this PR to remove local receiver mode and return to host-only package creation
