### PR TITLE
feat: add local mission transfer sender flow

### DIFF
--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -23,6 +23,8 @@ import com.cachekid.companion.host.importing.SharedTextPayload
 import com.cachekid.companion.host.mission.MissionDraft
 import com.cachekid.companion.host.mission.MissionPackageFileStore
 import com.cachekid.companion.host.mission.MissionPackageReceiverServer
+import com.cachekid.companion.host.mission.MissionPackageSendResult
+import com.cachekid.companion.host.mission.MissionPackageSenderClient
 import com.cachekid.companion.host.mission.MissionPackageStoreResult
 import com.cachekid.companion.host.mission.MissionPackageWriter
 import com.cachekid.companion.host.resolution.CacheResolutionResult
@@ -30,6 +32,9 @@ import com.cachekid.companion.host.resolution.HostCacheResolver
 import com.cachekid.companion.host.resolution.ManualCacheResolutionService
 import com.cachekid.companion.web.NativeBridge
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : AppCompatActivity() {
 
@@ -42,12 +47,14 @@ class MainActivity : AppCompatActivity() {
     private val missionDraftFactory = MissionDraftFactory()
     private val missionPackageWriter = MissionPackageWriter()
     private val missionPackageFileStore = MissionPackageFileStore()
+    private val missionPackageSenderClient = MissionPackageSenderClient()
 
     private var pendingImportResult: SharedCacheImportResult? = null
     private var pendingResolutionResult: CacheResolutionResult? = null
     private var pendingMissionDraft: MissionDraft? = null
     private var pendingShareDebug: String? = null
     private var storedMissionResult: MissionPackageStoreResult? = null
+    private var sendMissionResult: MissionPackageSendResult? = null
     private var receiveServer: MissionPackageReceiverServer? = null
     private var receiveServerRunning: Boolean = false
     private var receiveStatusText: String = "Empfang aus."
@@ -121,6 +128,21 @@ class MainActivity : AppCompatActivity() {
         }
         binding.nativeReceiveToggleButton.setOnClickListener {
             toggleReceiveMode()
+        }
+        binding.nativeSendMissionButton.setOnClickListener {
+            lifecycleScope.launch {
+                val result = withContext(Dispatchers.IO) {
+                    sendPendingMissionDraft(
+                        host = binding.nativeSendHostInput.text?.toString().orEmpty(),
+                        portText = binding.nativeSendPortInput.text?.toString().orEmpty(),
+                    )
+                }
+                Toast.makeText(
+                    this@MainActivity,
+                    result?.message ?: "Mission konnte nicht gesendet werden.",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
         }
 
         handleShareIntent(intent)
@@ -235,6 +257,7 @@ class MainActivity : AppCompatActivity() {
         pendingResolutionResult = pendingImportResult?.value?.let { hostCacheResolver.resolve(it) }
         pendingMissionDraft = pendingResolutionResult?.value?.let { missionDraftFactory.createFrom(it) }
         storedMissionResult = null
+        sendMissionResult = null
         refreshNativeImportPanel()
         if (::nativeBridge.isInitialized) {
             nativeBridge.notifyImportUpdated()
@@ -274,6 +297,12 @@ class MainActivity : AppCompatActivity() {
         binding.nativeStoredMissionStatus.text = storedMissionResult?.missionDirectory?.let { missionDirectory ->
             "Gespeichert in: ${missionDirectory.name}"
         }.orEmpty()
+        binding.nativeSendHostInput.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
+        binding.nativeSendPortInput.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
+        binding.nativeSendMissionButton.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
+        binding.nativeSendMissionStatus.visibility =
+            if (hasDraftReadyMission && sendMissionResult != null) View.VISIBLE else View.GONE
+        binding.nativeSendMissionStatus.text = sendMissionResult?.message.orEmpty()
 
         if (needsManualResolution && binding.nativeResolutionTitleInput.text.isNullOrBlank()) {
             binding.nativeResolutionTitleInput.setText(pendingResolutionResult?.cacheCodeHint.orEmpty())
@@ -287,7 +316,15 @@ class MainActivity : AppCompatActivity() {
         }
         if (!hasDraftReadyMission) {
             storedMissionResult = null
+            sendMissionResult = null
             binding.nativeStoredMissionStatus.text = ""
+            binding.nativeSendMissionStatus.text = ""
+        }
+        if (hasDraftReadyMission && binding.nativeSendPortInput.text.isNullOrBlank()) {
+            binding.nativeSendPortInput.setText(DEFAULT_RECEIVER_PORT.toString())
+        }
+        if (hasDraftReadyMission && binding.nativeSendHostInput.text.isNullOrBlank()) {
+            binding.nativeSendHostInput.setText(DEFAULT_RECEIVER_HOST)
         }
     }
 
@@ -385,6 +422,7 @@ class MainActivity : AppCompatActivity() {
         )
         pendingMissionDraft = missionDraftFactory.createFrom(resolvedCache)
         storedMissionResult = null
+        sendMissionResult = null
         refreshNativeImportPanel()
         if (::nativeBridge.isInitialized) {
             nativeBridge.notifyImportUpdated()
@@ -410,6 +448,30 @@ class MainActivity : AppCompatActivity() {
         )
         refreshNativeImportPanel()
         return storedMissionResult
+    }
+
+    private fun sendPendingMissionDraft(host: String, portText: String): MissionPackageSendResult? {
+        val draft = pendingMissionDraft ?: return null
+        val writeResult = missionPackageWriter.write(draft)
+        if (!writeResult.isSuccess) {
+            sendMissionResult = MissionPackageSendResult(
+                isSuccess = false,
+                statusCode = null,
+                message = writeResult.errors.joinToString(" "),
+            )
+            refreshNativeImportPanel()
+            return sendMissionResult
+        }
+
+        val missionPackage = writeResult.missionPackage ?: return null
+        val port = portText.trim().toIntOrNull()
+        sendMissionResult = missionPackageSenderClient.send(
+            host = host,
+            port = port ?: -1,
+            missionPackage = missionPackage,
+        )
+        refreshNativeImportPanel()
+        return sendMissionResult
     }
 
     private fun toggleReceiveMode() {
@@ -441,5 +503,7 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         const val DEFAULT_TARGET_TEXT = "52.520008,13.404954"
         const val MISSION_STORAGE_DIRECTORY = "missions"
+        const val DEFAULT_RECEIVER_HOST = "127.0.0.1"
+        const val DEFAULT_RECEIVER_PORT = 8765
     }
 }

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
@@ -1,0 +1,7 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackageSendResult(
+    val isSuccess: Boolean,
+    val statusCode: Int?,
+    val message: String,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
@@ -1,0 +1,74 @@
+package com.cachekid.companion.host.mission
+
+import java.net.ConnectException
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+
+class MissionPackageSenderClient(
+    private val zipCodec: MissionPackageZipCodec = MissionPackageZipCodec(),
+) {
+
+    fun send(
+        host: String,
+        port: Int,
+        missionPackage: MissionPackage,
+    ): MissionPackageSendResult {
+        val normalizedHost = host.trim()
+        if (normalizedHost.isBlank()) {
+            return MissionPackageSendResult(
+                isSuccess = false,
+                statusCode = null,
+                message = "Empfangsadresse fehlt.",
+            )
+        }
+        if (port !in 1..65535) {
+            return MissionPackageSendResult(
+                isSuccess = false,
+                statusCode = null,
+                message = "Port ist ungueltig.",
+            )
+        }
+
+        val payload = zipCodec.encode(missionPackage)
+        val connection = (URL("http://$normalizedHost:$port/missions").openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 5000
+            readTimeout = 5000
+            doOutput = true
+            setRequestProperty("Content-Type", "application/zip")
+            setRequestProperty("Content-Length", payload.size.toString())
+        }
+
+        return runCatching {
+            connection.outputStream.use { output ->
+                output.write(payload)
+            }
+            val statusCode = connection.responseCode
+            val responseText = runCatching {
+                val stream = if (statusCode in 200..299) connection.inputStream else connection.errorStream
+                stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            }.getOrDefault("")
+
+            MissionPackageSendResult(
+                isSuccess = statusCode in 200..299,
+                statusCode = statusCode,
+                message = responseText.ifBlank {
+                    if (statusCode in 200..299) "Mission gesendet." else "Transfer fehlgeschlagen."
+                },
+            )
+        }.getOrElse { error ->
+            MissionPackageSendResult(
+                isSuccess = false,
+                statusCode = null,
+                message = when (error) {
+                    is ConnectException -> "Verbindung zum Empfaenger fehlgeschlagen. Laeuft der Empfangsmodus?"
+                    is SocketTimeoutException -> "Empfaenger antwortet nicht rechtzeitig."
+                    else -> error.message ?: "Transfer fehlgeschlagen."
+                },
+            )
+        }.also {
+            connection.disconnect()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -88,6 +88,41 @@
             android:textColor="#5D5D55"
             android:textSize="12sp"
             android:visibility="gone" />
+
+        <EditText
+            android:id="@+id/nativeSendHostInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:hint="Empfangsadresse, z.B. 192.168.0.2"
+            android:inputType="textUri"
+            android:visibility="gone" />
+
+        <EditText
+            android:id="@+id/nativeSendPortInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="8765"
+            android:inputType="number"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/nativeSendMissionButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Mission senden"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/nativeSendMissionStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="#5D5D55"
+            android:textSize="12sp"
+            android:visibility="gone" />
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
@@ -1,0 +1,49 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.io.path.createTempDirectory
+
+class MissionPackageSenderClientTest {
+
+    private val writer = MissionPackageWriter()
+    private val senderClient = MissionPackageSenderClient()
+
+    @Test
+    fun `sender client posts a mission package to the local receiver`() {
+        val tempDir = createTempDirectory("cachekid-sender").toFile()
+        val statusMessages = mutableListOf<String>()
+        val receiver = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = { statusMessages.add(it) },
+        )
+        val port = receiver.start()
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val result = senderClient.send(
+                host = "127.0.0.1",
+                port = port,
+                missionPackage = missionPackage,
+            )
+
+            assertTrue(result.isSuccess)
+            assertTrue(result.message.contains("Stored ${missionPackage.missionId}"))
+            assertTrue(statusMessages.any { it.contains("Mission empfangen") })
+        } finally {
+            receiver.stop()
+        }
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(52.520008, 13.404954),
+            sourceApp = "geocaching",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add the host-side mission package sender client for the local receiver endpoint
- add simple host UI inputs for receiver address and port plus a send action
- run mission sending off the UI thread and report clearer transfer failures
- add sender-side automated coverage against the local receiver server

## Issue

Closes #22

## Validation

- [x] Android Studio unit test for MissionPackageSenderClientTest
- [x] Manual verification noted where automation is not yet possible

## Manual verification

- started receive mode in the app UI
- prepared and stored a mission locally
- sent the mission to the local receiver using 127.0.0.1:8765
- confirmed successful end-to-end transfer in the app UI

## Architecture

- keeps sender HTTP logic in a dedicated host mission client
- keeps MainActivity limited to sender orchestration and UI state
- builds on the existing package writer and receiver without changing their responsibility boundaries

## Risk

- User-facing risk: target host entry is still explicit/manual and not yet polished discovery UX
- Rollback path: revert this PR to remove sender UI and HTTP sender while leaving package writing and receiving intact
