### PR TITLE
Build host mission builder flow

### DIFF
--- a/app/src/main/assets/web/app.js
+++ b/app/src/main/assets/web/app.js
@@ -91,6 +91,11 @@ import {
   }
 
   function renderImportStatus() {
+    if (state.hasNativeHost) {
+      ui.importStatusBanner.hidden = true;
+      return;
+    }
+
     if (!state.importStatus && !state.shareDebug) {
       ui.importStatusBanner.hidden = true;
       return;
@@ -107,6 +112,11 @@ import {
   }
 
   function renderPendingResolution() {
+    if (state.hasNativeHost) {
+      ui.resolutionPanel.hidden = true;
+      return;
+    }
+
     if (!state.pendingResolution || state.pendingMissionDraft) {
       ui.resolutionPanel.hidden = true;
       return;
@@ -126,6 +136,11 @@ import {
   }
 
   function renderPendingMissionDraft() {
+    if (state.hasNativeHost) {
+      ui.importReviewPanel.hidden = true;
+      return;
+    }
+
     if (!state.pendingMissionDraft) {
       ui.importReviewPanel.hidden = true;
       return;
@@ -327,6 +342,7 @@ import {
     const rawDraft = window.AndroidHost.updatePendingMissionDraft(
       ui.childTitleInput.value,
       ui.summaryInput.value,
+      ui.targetInput.value,
     );
 
     if (rawDraft) {

--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -27,6 +27,8 @@ import com.cachekid.companion.host.mission.MissionPackageSendResult
 import com.cachekid.companion.host.mission.MissionPackageSenderClient
 import com.cachekid.companion.host.mission.MissionPackageStoreResult
 import com.cachekid.companion.host.mission.MissionPackageWriter
+import com.cachekid.companion.host.mission.MissionTargetParser
+import com.cachekid.companion.host.mission.HostMissionBuilderPresenter
 import com.cachekid.companion.host.resolution.CacheResolutionResult
 import com.cachekid.companion.host.resolution.HostCacheResolver
 import com.cachekid.companion.host.resolution.ManualCacheResolutionService
@@ -48,6 +50,8 @@ class MainActivity : AppCompatActivity() {
     private val missionPackageWriter = MissionPackageWriter()
     private val missionPackageFileStore = MissionPackageFileStore()
     private val missionPackageSenderClient = MissionPackageSenderClient()
+    private val missionTargetParser = MissionTargetParser()
+    private val hostMissionBuilderPresenter = HostMissionBuilderPresenter(missionTargetParser)
 
     private var pendingImportResult: SharedCacheImportResult? = null
     private var pendingResolutionResult: CacheResolutionResult? = null
@@ -110,6 +114,26 @@ class MainActivity : AppCompatActivity() {
                 ).show()
             }
         }
+        binding.nativeUpdateMissionButton.setOnClickListener {
+            val draft = updatePendingMissionDraft(
+                childTitle = binding.nativeMissionChildTitleInput.text?.toString().orEmpty(),
+                summary = binding.nativeMissionSummaryInput.text?.toString().orEmpty(),
+                targetText = binding.nativeMissionTargetInput.text?.toString().orEmpty(),
+            )
+            if (draft == null) {
+                Toast.makeText(
+                    this,
+                    "Bitte Kindertitel, Kurztext und Ziel pruefen.",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            } else {
+                Toast.makeText(
+                    this,
+                    "Missionsdaten aktualisiert.",
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
         binding.nativeSaveMissionButton.setOnClickListener {
             val result = storePendingMissionDraft()
             if (result?.isSuccess == true) {
@@ -137,6 +161,7 @@ class MainActivity : AppCompatActivity() {
                         portText = binding.nativeSendPortInput.text?.toString().orEmpty(),
                     )
                 }
+                refreshNativeImportPanel()
                 Toast.makeText(
                     this@MainActivity,
                     result?.message ?: "Mission konnte nicht gesendet werden.",
@@ -265,65 +290,79 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun refreshNativeImportPanel() {
-        val summary = pendingImportSummary()
-        val debug = pendingShareDebug
-        if (summary == null && debug == null) {
+        val panelState = hostMissionBuilderPresenter.present(
+            importSummary = pendingImportSummary(),
+            shareDebug = pendingShareDebug,
+            resolutionResult = pendingResolutionResult,
+            missionDraft = pendingMissionDraft,
+            storedMissionResult = storedMissionResult,
+            sendMissionResult = sendMissionResult,
+            defaultTargetText = DEFAULT_TARGET_TEXT,
+        )
+        if (!panelState.isVisible) {
             binding.nativeImportPanel.visibility = View.GONE
             return
         }
 
         binding.nativeImportPanel.visibility = View.VISIBLE
-        binding.nativeImportTitle.text = when {
-            pendingMissionDraft != null -> "Mission bereit"
-            pendingResolutionResult?.status == com.cachekid.companion.host.resolution.CacheResolutionStatus.NEEDS_ONLINE_RESOLUTION ->
-                "Cache erkannt"
-            else -> "Import"
-        }
-        binding.nativeImportStatus.text = summary ?: "Share-Intent empfangen."
+        binding.nativeImportTitle.text = panelState.panelTitle
+        binding.nativeImportStatus.text = panelState.panelStatus
 
-        val needsManualResolution =
-            pendingMissionDraft == null &&
-                pendingResolutionResult?.status == com.cachekid.companion.host.resolution.CacheResolutionStatus.NEEDS_ONLINE_RESOLUTION
-        val hasDraftReadyMission = pendingMissionDraft != null
+        binding.nativeImportDebug.visibility = if (panelState.debugText != null) View.VISIBLE else View.GONE
+        binding.nativeImportDebug.text = panelState.debugText.orEmpty()
 
-        binding.nativeImportDebug.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
-        binding.nativeImportDebug.text = if (needsManualResolution) debug.orEmpty() else ""
-        binding.nativeResolutionTitleInput.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
-        binding.nativeResolutionTargetInput.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
-        binding.nativeResolveButton.visibility = if (needsManualResolution) View.VISIBLE else View.GONE
-        binding.nativeSaveMissionButton.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
-        binding.nativeStoredMissionStatus.visibility =
-            if (hasDraftReadyMission && storedMissionResult?.isSuccess == true) View.VISIBLE else View.GONE
-        binding.nativeStoredMissionStatus.text = storedMissionResult?.missionDirectory?.let { missionDirectory ->
-            "Gespeichert in: ${missionDirectory.name}"
-        }.orEmpty()
-        binding.nativeSendHostInput.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
-        binding.nativeSendPortInput.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
-        binding.nativeSendMissionButton.visibility = if (hasDraftReadyMission) View.VISIBLE else View.GONE
-        binding.nativeSendMissionStatus.visibility =
-            if (hasDraftReadyMission && sendMissionResult != null) View.VISIBLE else View.GONE
-        binding.nativeSendMissionStatus.text = sendMissionResult?.message.orEmpty()
+        binding.nativeResolutionTitleInput.visibility =
+            if (panelState.showManualResolution) View.VISIBLE else View.GONE
+        binding.nativeResolutionTargetInput.visibility =
+            if (panelState.showManualResolution) View.VISIBLE else View.GONE
+        binding.nativeResolveButton.visibility =
+            if (panelState.showManualResolution) View.VISIBLE else View.GONE
 
-        if (needsManualResolution && binding.nativeResolutionTitleInput.text.isNullOrBlank()) {
-            binding.nativeResolutionTitleInput.setText(pendingResolutionResult?.cacheCodeHint.orEmpty())
+        if (panelState.showManualResolution && binding.nativeResolutionTitleInput.text.isNullOrBlank()) {
+            binding.nativeResolutionTitleInput.setText(panelState.manualResolutionTitle)
         }
-        if (needsManualResolution && binding.nativeResolutionTargetInput.text.isNullOrBlank()) {
-            binding.nativeResolutionTargetInput.setText(DEFAULT_TARGET_TEXT)
+        if (panelState.showManualResolution && binding.nativeResolutionTargetInput.text.isNullOrBlank()) {
+            binding.nativeResolutionTargetInput.setText(panelState.manualResolutionTarget)
         }
-        if (!needsManualResolution) {
+        if (!panelState.showManualResolution) {
             binding.nativeResolutionTitleInput.text?.clear()
             binding.nativeResolutionTargetInput.text?.clear()
         }
-        if (!hasDraftReadyMission) {
+
+        binding.nativeMissionReviewSection.visibility =
+            if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeUpdateMissionButton.visibility =
+            if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeMissionBuilderHint.visibility =
+            if (panelState.showMissionBuilder && panelState.builderHint != null) View.VISIBLE else View.GONE
+        binding.nativeMissionBuilderHint.text = panelState.builderHint.orEmpty()
+        binding.nativeMissionCacheCode.text = panelState.missionCacheCode
+        binding.nativeMissionSourceTitle.text = panelState.missionSourceTitle
+        binding.nativeMissionChildTitleInput.setText(panelState.missionChildTitle)
+        binding.nativeMissionSummaryInput.setText(panelState.missionSummary)
+        binding.nativeMissionTargetInput.setText(panelState.missionTargetText)
+
+        binding.nativeSaveMissionButton.visibility = if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeStoredMissionStatus.visibility =
+            if (panelState.showStoredStatus) View.VISIBLE else View.GONE
+        binding.nativeStoredMissionStatus.text = panelState.storedStatus.orEmpty()
+        binding.nativeSendHostInput.visibility = if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeSendPortInput.visibility = if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeSendMissionButton.visibility = if (panelState.showMissionBuilder) View.VISIBLE else View.GONE
+        binding.nativeSendMissionStatus.visibility =
+            if (panelState.showSendStatus) View.VISIBLE else View.GONE
+        binding.nativeSendMissionStatus.text = panelState.sendStatus.orEmpty()
+
+        if (!panelState.showMissionBuilder) {
             storedMissionResult = null
             sendMissionResult = null
             binding.nativeStoredMissionStatus.text = ""
             binding.nativeSendMissionStatus.text = ""
         }
-        if (hasDraftReadyMission && binding.nativeSendPortInput.text.isNullOrBlank()) {
+        if (panelState.showMissionBuilder && binding.nativeSendPortInput.text.isNullOrBlank()) {
             binding.nativeSendPortInput.setText(DEFAULT_RECEIVER_PORT.toString())
         }
-        if (hasDraftReadyMission && binding.nativeSendHostInput.text.isNullOrBlank()) {
+        if (panelState.showMissionBuilder && binding.nativeSendHostInput.text.isNullOrBlank()) {
             binding.nativeSendHostInput.setText(DEFAULT_RECEIVER_HOST)
         }
     }
@@ -389,11 +428,17 @@ class MainActivity : AppCompatActivity() {
         return "${result.status.name.lowercase()}: $draftState: $messageText"
     }
 
-    private fun updatePendingMissionDraft(childTitle: String, summary: String): MissionDraft? {
+    private fun updatePendingMissionDraft(
+        childTitle: String,
+        summary: String,
+        targetText: String,
+    ): MissionDraft? {
         val currentDraft = pendingMissionDraft ?: return null
+        val target = missionTargetParser.parse(targetText) ?: return null
         pendingMissionDraft = currentDraft.copy(
             childTitle = childTitle.trim().ifBlank { currentDraft.childTitle },
             summary = summary.trim().ifBlank { currentDraft.summary },
+            target = target,
         )
         refreshNativeImportPanel()
         if (::nativeBridge.isInitialized) {
@@ -459,7 +504,6 @@ class MainActivity : AppCompatActivity() {
                 statusCode = null,
                 message = writeResult.errors.joinToString(" "),
             )
-            refreshNativeImportPanel()
             return sendMissionResult
         }
 
@@ -470,7 +514,6 @@ class MainActivity : AppCompatActivity() {
             port = port ?: -1,
             missionPackage = missionPackage,
         )
-        refreshNativeImportPanel()
         return sendMissionResult
     }
 

--- a/app/src/main/java/com/cachekid/companion/host/mission/HostMissionBuilderPresenter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/HostMissionBuilderPresenter.kt
@@ -1,0 +1,91 @@
+package com.cachekid.companion.host.mission
+
+import com.cachekid.companion.host.resolution.CacheResolutionResult
+import com.cachekid.companion.host.resolution.CacheResolutionStatus
+
+class HostMissionBuilderPresenter(
+    private val missionTargetParser: MissionTargetParser = MissionTargetParser(),
+) {
+
+    fun present(
+        importSummary: String?,
+        shareDebug: String?,
+        resolutionResult: CacheResolutionResult?,
+        missionDraft: MissionDraft?,
+        storedMissionResult: MissionPackageStoreResult?,
+        sendMissionResult: MissionPackageSendResult?,
+        defaultTargetText: String,
+    ): HostMissionBuilderPanelState {
+        val isVisible = importSummary != null || shareDebug != null
+        if (!isVisible) {
+            return HostMissionBuilderPanelState(isVisible = false)
+        }
+
+        val needsManualResolution =
+            missionDraft == null &&
+                resolutionResult?.status == CacheResolutionStatus.NEEDS_ONLINE_RESOLUTION
+        val hasDraftReadyMission = missionDraft != null
+
+        val panelTitle = when {
+            hasDraftReadyMission -> "Mission vorbereiten"
+            needsManualResolution -> "Cache erkannt"
+            else -> "Import"
+        }
+
+        val panelStatus = when {
+            hasDraftReadyMission -> "Titel, Kurztext und Ziel fuer das Kind pruefen."
+            else -> importSummary ?: "Share-Intent empfangen."
+        }
+
+        val builderHint = when {
+            !hasDraftReadyMission -> null
+            sendMissionResult?.isSuccess == true -> "Mission wurde erfolgreich an das Tablet gesendet."
+            storedMissionResult?.isSuccess == true -> "Mission ist lokal gespeichert und bereit zum Senden."
+            else -> "Danach lokal speichern oder direkt an das Tablet senden."
+        }
+
+        return HostMissionBuilderPanelState(
+            isVisible = true,
+            panelTitle = panelTitle,
+            panelStatus = panelStatus,
+            debugText = if (needsManualResolution) shareDebug else null,
+            showManualResolution = needsManualResolution,
+            manualResolutionTitle = resolutionResult?.cacheCodeHint.orEmpty(),
+            manualResolutionTarget = defaultTargetText,
+            showMissionBuilder = hasDraftReadyMission,
+            missionCacheCode = missionDraft?.cacheCode.orEmpty(),
+            missionSourceTitle = missionDraft?.sourceTitle.orEmpty(),
+            missionChildTitle = missionDraft?.childTitle.orEmpty(),
+            missionSummary = missionDraft?.summary.orEmpty(),
+            missionTargetText = missionDraft?.let { missionTargetParser.format(it.target) }.orEmpty(),
+            builderHint = builderHint,
+            showStoredStatus = storedMissionResult?.isSuccess == true,
+            storedStatus = storedMissionResult?.missionDirectory?.name?.let { missionId ->
+                "Gespeichert in: $missionId"
+            },
+            showSendStatus = sendMissionResult != null,
+            sendStatus = sendMissionResult?.message,
+        )
+    }
+}
+
+data class HostMissionBuilderPanelState(
+    val isVisible: Boolean,
+    val panelTitle: String = "",
+    val panelStatus: String = "",
+    val debugText: String? = null,
+    val showManualResolution: Boolean = false,
+    val manualResolutionTitle: String = "",
+    val manualResolutionTarget: String = "",
+    val showMissionBuilder: Boolean = false,
+    val missionCacheCode: String = "",
+    val missionSourceTitle: String = "",
+    val missionChildTitle: String = "",
+    val missionSummary: String = "",
+    val missionTargetText: String = "",
+    val builderHint: String? = null,
+    val showStoredStatus: Boolean = false,
+    val storedStatus: String? = null,
+    val showSendStatus: Boolean = false,
+    val sendStatus: String? = null,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionTargetParser.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionTargetParser.kt
@@ -1,0 +1,19 @@
+package com.cachekid.companion.host.mission
+
+class MissionTargetParser {
+
+    fun parse(text: String): MissionTarget? {
+        val match = DECIMAL_COORDINATE_REGEX.matchEntire(text.trim()) ?: return null
+        val latitude = match.groupValues[1].toDoubleOrNull() ?: return null
+        val longitude = match.groupValues[2].toDoubleOrNull() ?: return null
+        return MissionTarget(latitude = latitude, longitude = longitude).takeIf { it.isValid() }
+    }
+
+    fun format(target: MissionTarget): String {
+        return "${target.latitude},${target.longitude}"
+    }
+
+    private companion object {
+        val DECIMAL_COORDINATE_REGEX = Regex("""\s*(-?\d{1,2}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)\s*""")
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/resolution/ManualCacheResolutionService.kt
+++ b/app/src/main/java/com/cachekid/companion/host/resolution/ManualCacheResolutionService.kt
@@ -1,8 +1,11 @@
 package com.cachekid.companion.host.resolution
 
 import com.cachekid.companion.host.mission.MissionTarget
+import com.cachekid.companion.host.mission.MissionTargetParser
 
 class ManualCacheResolutionService {
+
+    private val missionTargetParser = MissionTargetParser()
 
     fun resolve(
         cacheCode: String?,
@@ -12,7 +15,7 @@ class ManualCacheResolutionService {
     ): ResolvedCacheDetails? {
         val normalizedCode = cacheCode?.trim()?.takeIf { it.isNotBlank() } ?: return null
         val normalizedTitle = title.trim().takeIf { it.isNotBlank() } ?: return null
-        val target = parseTarget(coordinateText) ?: return null
+        val target = missionTargetParser.parse(coordinateText) ?: return null
 
         return ResolvedCacheDetails(
             cacheCode = normalizedCode,
@@ -20,16 +23,5 @@ class ManualCacheResolutionService {
             target = target,
             sourceApp = sourceApp,
         )
-    }
-
-    private fun parseTarget(text: String): MissionTarget? {
-        val match = DECIMAL_COORDINATE_REGEX.matchEntire(text.trim()) ?: return null
-        val latitude = match.groupValues[1].toDoubleOrNull() ?: return null
-        val longitude = match.groupValues[2].toDoubleOrNull() ?: return null
-        return MissionTarget(latitude = latitude, longitude = longitude).takeIf { it.isValid() }
-    }
-
-    private companion object {
-        val DECIMAL_COORDINATE_REGEX = Regex("""\s*(-?\d{1,2}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)\s*""")
     }
 }

--- a/app/src/main/java/com/cachekid/companion/web/NativeBridge.kt
+++ b/app/src/main/java/com/cachekid/companion/web/NativeBridge.kt
@@ -24,7 +24,7 @@ class NativeBridge(
     private val getPendingShareDebugAction: () -> String?,
     private val getPendingMissionDraft: () -> MissionDraft?,
     private val getPendingResolution: () -> CacheResolutionResult?,
-    private val updatePendingMissionDraftAction: (String, String) -> MissionDraft?,
+    private val updatePendingMissionDraftAction: (String, String, String) -> MissionDraft?,
     private val resolvePendingCacheManuallyAction: (String, String) -> MissionDraft?,
 ) {
 
@@ -86,8 +86,8 @@ class NativeBridge(
     }
 
     @JavascriptInterface
-    fun updatePendingMissionDraft(childTitle: String, summary: String): String? {
-        val draft = updatePendingMissionDraftAction(childTitle, summary) ?: return null
+    fun updatePendingMissionDraft(childTitle: String, summary: String, targetText: String): String? {
+        val draft = updatePendingMissionDraftAction(childTitle, summary, targetText) ?: return null
         return draft.toJson()
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -72,6 +72,100 @@
             android:text="Mission manuell anlegen"
             android:visibility="gone" />
 
+        <LinearLayout
+            android:id="@+id/nativeMissionReviewSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Mission pruefen"
+                android:textColor="#151515"
+                android:textSize="13sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Cache-Code"
+                android:textColor="#5D5D55"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/nativeMissionCacheCode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="#151515"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Originaltitel"
+                android:textColor="#5D5D55"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/nativeMissionSourceTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="#151515"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <EditText
+                android:id="@+id/nativeMissionChildTitleInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="Titel fuer das Kind"
+                android:inputType="textCapSentences" />
+
+            <EditText
+                android:id="@+id/nativeMissionSummaryInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:gravity="top|start"
+                android:hint="Kurze Missionsbeschreibung"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="3" />
+
+            <EditText
+                android:id="@+id/nativeMissionTargetInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="Zielkoordinate"
+                android:inputType="text" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/nativeUpdateMissionButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Missionsdaten uebernehmen"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/nativeMissionBuilderHint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="#5D5D55"
+            android:textSize="12sp"
+            android:visibility="gone" />
+
         <Button
             android:id="@+id/nativeSaveMissionButton"
             android:layout_width="match_parent"

--- a/app/src/test/java/com/cachekid/companion/host/mission/HostMissionBuilderPresenterTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/HostMissionBuilderPresenterTest.kt
@@ -1,0 +1,70 @@
+package com.cachekid.companion.host.mission
+
+import com.cachekid.companion.host.resolution.CacheResolutionResult
+import com.cachekid.companion.host.resolution.CacheResolutionStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HostMissionBuilderPresenterTest {
+
+    private val presenter = HostMissionBuilderPresenter()
+
+    @Test
+    fun `presenter shows manual resolution state when only cache code is known`() {
+        val state = presenter.present(
+            importSummary = "partial: needs_online_resolution: Cache erkannt.",
+            shareDebug = "action=android.intent.action.SEND",
+            resolutionResult = CacheResolutionResult(
+                status = CacheResolutionStatus.NEEDS_ONLINE_RESOLUTION,
+                value = null,
+                messages = listOf("Cache erkannt."),
+                cacheCodeHint = "GC7NXFT",
+            ),
+            missionDraft = null,
+            storedMissionResult = null,
+            sendMissionResult = null,
+            defaultTargetText = "52.520008,13.404954",
+        )
+
+        assertTrue(state.isVisible)
+        assertEquals("Cache erkannt", state.panelTitle)
+        assertTrue(state.showManualResolution)
+        assertFalse(state.showMissionBuilder)
+        assertEquals("GC7NXFT", state.manualResolutionTitle)
+    }
+
+    @Test
+    fun `presenter shows builder state for ready mission`() {
+        val state = presenter.present(
+            importSummary = "draft-ready: Cache manuell vervollstaendigt.",
+            shareDebug = "debug",
+            resolutionResult = CacheResolutionResult(
+                status = CacheResolutionStatus.RESOLVED,
+                value = null,
+                messages = listOf("Cache manuell vervollstaendigt."),
+                cacheCodeHint = "GC7NXFT",
+            ),
+            missionDraft = MissionDraft(
+                cacheCode = "GC7NXFT",
+                sourceTitle = "Old Oak Cache",
+                childTitle = "Der alte Baum",
+                summary = "Folge der Karte bis zum grossen X.",
+                target = MissionTarget(52.520008, 13.404954),
+            ),
+            storedMissionResult = MissionPackageStoreResult(
+                missionDirectory = null,
+                errors = emptyList(),
+            ),
+            sendMissionResult = null,
+            defaultTargetText = "52.520008,13.404954",
+        )
+
+        assertEquals("Mission vorbereiten", state.panelTitle)
+        assertEquals("Der alte Baum", state.missionChildTitle)
+        assertEquals("52.520008,13.404954", state.missionTargetText)
+        assertTrue(state.showMissionBuilder)
+        assertFalse(state.showManualResolution)
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionTargetParserTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionTargetParserTest.kt
@@ -1,0 +1,26 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MissionTargetParserTest {
+
+    private val parser = MissionTargetParser()
+
+    @Test
+    fun `parser reads decimal coordinates`() {
+        val target = parser.parse("52.520008, 13.404954")
+
+        assertNotNull(target)
+        assertEquals(52.520008, target?.latitude ?: 0.0, 0.000001)
+        assertEquals(13.404954, target?.longitude ?: 0.0, 0.000001)
+    }
+
+    @Test
+    fun `parser rejects invalid coordinate text`() {
+        assertNull(parser.parse("not-a-coordinate"))
+        assertNull(parser.parse("95.0,13.4"))
+    }
+}


### PR DESCRIPTION
## Summary
- turn the host import panel into a real parent-facing mission builder
- add a presenter and shared target parser so mission review state is testable
- let the host update child title, summary, and target before saving or sending

## Testing
- npm run check:web
- npm run test:web
- Android Studio: HostMissionBuilderPresenterTest
- Android Studio: MissionTargetParserTest
- Android Studio manual flow: share -> manual resolve -> update mission -> save/send
