### PR TITLE
[codex] Add kid mission sideload path

### DIFF
--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -36,6 +36,8 @@ import com.cachekid.companion.host.mission.DeviceOfflineBaseMapRepository
 import com.cachekid.companion.host.mission.MissionDraft
 import com.cachekid.companion.host.mission.MissionPackageFileStore
 import com.cachekid.companion.host.mission.MissionPackageReceiverServer
+import com.cachekid.companion.host.mission.MissionPackageSideloadImporter
+import com.cachekid.companion.host.mission.MissionPackageSideloadStatus
 import com.cachekid.companion.host.mission.MissionPackageSendResult
 import com.cachekid.companion.host.mission.MissionPackageSenderClient
 import com.cachekid.companion.host.mission.MissionPackageStoreResult
@@ -75,6 +77,7 @@ class MainActivity : AppCompatActivity() {
     private val missionDraftFactory = MissionDraftFactory()
     private val missionPackageWriter = MissionPackageWriter()
     private val missionPackageFileStore = MissionPackageFileStore()
+    private val missionPackageSideloadImporter = MissionPackageSideloadImporter()
     private val missionPackageSenderClient = MissionPackageSenderClient()
     private val missionTargetParser = MissionTargetParser()
     private val hostMissionBuilderPresenter = HostMissionBuilderPresenter(missionTargetParser)
@@ -93,6 +96,8 @@ class MainActivity : AppCompatActivity() {
     private var receiveServer: MissionPackageReceiverServer? = null
     private var receiveServerRunning: Boolean = false
     private var receiveStatusText: String = "Empfang aus."
+    private var sideloadStatusText: String = "Kein adb-Sideload importiert."
+    private var sideloadImportRunning: Boolean = false
     private var importSessionId: Long = 0L
     private var latestLocation: Location? = null
     private lateinit var deviceOfflineBaseMapRepository: DeviceOfflineBaseMapRepository
@@ -255,6 +260,9 @@ class MainActivity : AppCompatActivity() {
         binding.nativeReceiveToggleButton.setOnClickListener {
             toggleReceiveMode()
         }
+        binding.nativeSideloadImportButton.setOnClickListener {
+            importPendingSideloadMission(showToast = true)
+        }
         binding.nativeSendMissionButton.setOnClickListener {
             lifecycleScope.launch {
                 val result = withContext(Dispatchers.IO) {
@@ -273,6 +281,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         activeMission = loadActiveMission()
+        importPendingSideloadMission(showToast = activeMission == null)
         handleShareIntent(intent)
         refreshNativeImportPanel()
         refreshReceivePanel()
@@ -293,6 +302,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         kidNativeMapController.onResume()
+        importPendingSideloadMission(showToast = activeMission == null)
         if (hasLocationPermissions()) {
             nativeBridge.startNativeSensors()
         }
@@ -602,6 +612,9 @@ class MainActivity : AppCompatActivity() {
 
         binding.nativeReceivePanel.visibility = View.VISIBLE
         binding.nativeReceiveStatus.text = receiveStatusText
+        binding.nativeSideloadHint.text =
+            "ADB-Sideload: ZIP nach ${preferredSideloadDirectory().absolutePath} pushen."
+        binding.nativeSideloadStatus.text = sideloadStatusText
         binding.nativeReceiveToggleButton.text = if (receiveServerRunning) {
             "Empfang stoppen"
         } else {
@@ -897,6 +910,93 @@ class MainActivity : AppCompatActivity() {
             ?.let(::attachDeviceBaseMap)
     }
 
+    private fun importPendingSideloadMission(showToast: Boolean) {
+        if (sideloadImportRunning) {
+            return
+        }
+        sideloadImportRunning = true
+        lifecycleScope.launch {
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    missionPackageSideloadImporter.importLatest(
+                        missionBaseDirectory = File(filesDir, MISSION_STORAGE_DIRECTORY),
+                        candidateDirectories = sideloadDirectories(),
+                    )
+                }
+
+                when (result.status) {
+                    MissionPackageSideloadStatus.NO_PACKAGE_FOUND -> {
+                        sideloadStatusText = result.message
+                        refreshReceivePanel()
+                    }
+
+                    MissionPackageSideloadStatus.IMPORTED -> {
+                        activeMission = loadActiveMission()
+                        sideloadStatusText = buildString {
+                            append(result.message)
+                            result.archivedFile?.let {
+                                append(" Archiv: ")
+                                append(it.absolutePath)
+                            }
+                        }
+                        Log.d(
+                            RESOLVER_LOG_TAG,
+                            "sideload-imported source=${result.sourceFile?.absolutePath} archived=${result.archivedFile?.absolutePath} mission=${result.importResult?.missionId}",
+                        )
+                        refreshNativeImportPanel()
+                        refreshReceivePanel()
+                        refreshNativeMap()
+                        if (::nativeBridge.isInitialized) {
+                            nativeBridge.notifyActiveMissionUpdated()
+                        }
+                        if (showToast) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                result.message,
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    }
+
+                    MissionPackageSideloadStatus.IMPORT_FAILED -> {
+                        sideloadStatusText = buildString {
+                            append(result.message)
+                            result.errors.firstOrNull()?.let {
+                                append(" ")
+                                append(it)
+                            }
+                        }
+                        Log.w(
+                            RESOLVER_LOG_TAG,
+                            "sideload-import-failed source=${result.sourceFile?.absolutePath} archived=${result.archivedFile?.absolutePath} errors=${result.errors.joinToString(" | ")}",
+                        )
+                        refreshReceivePanel()
+                        if (showToast) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                sideloadStatusText,
+                                Toast.LENGTH_LONG,
+                            ).show()
+                        }
+                    }
+                }
+            } finally {
+                sideloadImportRunning = false
+            }
+        }
+    }
+
+    private fun sideloadDirectories(): List<File> {
+        val internalDirectory = File(filesDir, MISSION_SIDELOAD_DIRECTORY).apply { mkdirs() }
+        val externalDirectory = getExternalFilesDir(null)
+            ?.let { File(it, MISSION_SIDELOAD_DIRECTORY).apply { mkdirs() } }
+        return listOfNotNull(externalDirectory, internalDirectory)
+    }
+
+    private fun preferredSideloadDirectory(): File {
+        return sideloadDirectories().first()
+    }
+
     private fun attachDeviceBaseMap(mission: ActiveMission): ActiveMission {
         return mission.copy(
             baseMap = deviceOfflineBaseMapRepository.loadFor(mission.target),
@@ -1033,6 +1133,7 @@ class MainActivity : AppCompatActivity() {
         const val RESOLVER_LOG_TAG = "CacheKidResolver"
         const val DEFAULT_TARGET_TEXT = ""
         const val MISSION_STORAGE_DIRECTORY = "missions"
+        const val MISSION_SIDELOAD_DIRECTORY = "mission-sideload"
         const val OFFLINE_BASEMAP_DIRECTORY = "offline-basemaps"
         const val DEFAULT_RECEIVER_HOST = "127.0.0.1"
         const val DEFAULT_RECEIVER_PORT = 8765

--- a/app/src/main/java/com/cachekid/companion/host/mission/DeviceOfflineBaseMapRepository.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/DeviceOfflineBaseMapRepository.kt
@@ -30,7 +30,10 @@ class DeviceOfflineBaseMapRepository(
             ?.readText()
             ?: return null
 
-        val assetPath = extractStringValue(metaJson, "assetPath") ?: MissionPackageSchema.MAP_SVG_FILE
+        val assetPath = selectPreferredAssetPath(
+            mapDirectory = mapDirectory,
+            configuredAssetPath = extractStringValue(metaJson, "assetPath"),
+        ) ?: return null
         val boundsJson = extractObject(metaJson, "bounds") ?: return null
         val svgContent = File(mapDirectory, assetPath)
             .takeIf { it.exists() && it.isFile }
@@ -54,6 +57,30 @@ class DeviceOfflineBaseMapRepository(
             wrapPngAsSvgSnippet(assetFile.readBytes(), assetPath)
         } else {
             unwrapSvgDocument(assetFile.readText())
+        }
+    }
+
+    private fun selectPreferredAssetPath(
+        mapDirectory: File,
+        configuredAssetPath: String?,
+    ): String? {
+        val pngFile = File(mapDirectory, MissionPackageSchema.MAP_PNG_FILE)
+        if (pngFile.exists() && pngFile.isFile) {
+            return MissionPackageSchema.MAP_PNG_FILE
+        }
+
+        val configuredFile = configuredAssetPath
+            ?.let { File(mapDirectory, it) }
+            ?.takeIf { it.exists() && it.isFile }
+        if (configuredFile != null) {
+            return configuredFile.name
+        }
+
+        val svgFile = File(mapDirectory, MissionPackageSchema.MAP_SVG_FILE)
+        return if (svgFile.exists() && svgFile.isFile) {
+            MissionPackageSchema.MAP_SVG_FILE
+        } else {
+            null
         }
     }
 

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSideloadImporter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSideloadImporter.kt
@@ -1,0 +1,141 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+class MissionPackageSideloadImporter(
+    private val importer: MissionPackageZipImporter = MissionPackageZipImporter(),
+) {
+
+    fun importLatest(
+        missionBaseDirectory: File,
+        candidateDirectories: List<File>,
+    ): MissionPackageSideloadResult {
+        val normalizedDirectories = candidateDirectories
+            .distinctBy { it.absolutePath }
+
+        val latestPackage = normalizedDirectories
+            .asSequence()
+            .filter { it.exists() && it.isDirectory }
+            .flatMap { directory ->
+                directory.listFiles()
+                    .orEmpty()
+                    .asSequence()
+                    .filter { file ->
+                        file.isFile &&
+                            file.extension.equals("zip", ignoreCase = true)
+                    }
+            }
+            .maxByOrNull { it.lastModified() }
+
+        if (latestPackage == null) {
+            return MissionPackageSideloadResult(
+                status = MissionPackageSideloadStatus.NO_PACKAGE_FOUND,
+                message = "Kein adb-Sideload-Paket gefunden.",
+                searchedDirectories = normalizedDirectories,
+            )
+        }
+
+        val zipBytes = runCatching { latestPackage.readBytes() }
+            .getOrElse { error ->
+                val archivedFile = archive(latestPackage, FAILED_DIRECTORY_NAME)
+                val errorReport = writeErrorReport(archivedFile ?: latestPackage, error.message ?: "Unbekannter Lesefehler.")
+                return MissionPackageSideloadResult(
+                    status = MissionPackageSideloadStatus.IMPORT_FAILED,
+                    sourceFile = latestPackage,
+                    archivedFile = archivedFile,
+                    errorReportFile = errorReport,
+                    message = "Sideload-Paket konnte nicht gelesen werden: ${latestPackage.name}",
+                    errors = listOf(error.message ?: "Unbekannter Lesefehler."),
+                    searchedDirectories = normalizedDirectories,
+                )
+            }
+
+        val importResult = importer.import(missionBaseDirectory, zipBytes)
+        return if (importResult.isSuccess) {
+            MissionPackageSideloadResult(
+                status = MissionPackageSideloadStatus.IMPORTED,
+                sourceFile = latestPackage,
+                archivedFile = archive(latestPackage, IMPORTED_DIRECTORY_NAME),
+                importResult = importResult,
+                message = "ADB-Sideload importiert: ${importResult.missionId}",
+                searchedDirectories = normalizedDirectories,
+            )
+        } else {
+            val archivedFile = archive(latestPackage, FAILED_DIRECTORY_NAME)
+            val errorReport = writeErrorReport(archivedFile ?: latestPackage, importResult.errors.joinToString("\n"))
+            MissionPackageSideloadResult(
+                status = MissionPackageSideloadStatus.IMPORT_FAILED,
+                sourceFile = latestPackage,
+                archivedFile = archivedFile,
+                errorReportFile = errorReport,
+                importResult = importResult,
+                message = "ADB-Sideload fehlgeschlagen: ${latestPackage.name}",
+                errors = importResult.errors,
+                searchedDirectories = normalizedDirectories,
+            )
+        }
+    }
+
+    private fun archive(sourceFile: File, archiveDirectoryName: String): File? {
+        val archiveDirectory = File(sourceFile.parentFile, archiveDirectoryName)
+        archiveDirectory.mkdirs()
+        val archivedFile = uniqueArchiveFile(archiveDirectory, sourceFile)
+        if (sourceFile.renameTo(archivedFile)) {
+            return archivedFile
+        }
+
+        return runCatching {
+            sourceFile.copyTo(target = archivedFile, overwrite = false)
+            if (!sourceFile.delete()) {
+                archivedFile.delete()
+                null
+            } else {
+                archivedFile
+            }
+        }.getOrNull()
+    }
+
+    private fun uniqueArchiveFile(archiveDirectory: File, sourceFile: File): File {
+        val baseName = sourceFile.nameWithoutExtension
+        val extension = sourceFile.extension.takeIf { it.isNotBlank() }?.let { ".$it" }.orEmpty()
+        var attempt = 0
+        while (true) {
+            val suffix = if (attempt == 0) "" else "-$attempt"
+            val candidate = File(archiveDirectory, "$baseName$suffix$extension")
+            if (!candidate.exists()) {
+                return candidate
+            }
+            attempt += 1
+        }
+    }
+
+    private fun writeErrorReport(referenceFile: File, errorText: String): File? {
+        val reportFile = File(referenceFile.parentFile, "${referenceFile.name}.error.txt")
+        return runCatching {
+            reportFile.writeText(errorText)
+            reportFile
+        }.getOrNull()
+    }
+
+    companion object {
+        const val IMPORTED_DIRECTORY_NAME = "imported"
+        const val FAILED_DIRECTORY_NAME = "failed"
+    }
+}
+
+data class MissionPackageSideloadResult(
+    val status: MissionPackageSideloadStatus,
+    val sourceFile: File? = null,
+    val archivedFile: File? = null,
+    val errorReportFile: File? = null,
+    val importResult: MissionPackageImportResult? = null,
+    val message: String,
+    val errors: List<String> = emptyList(),
+    val searchedDirectories: List<File> = emptyList(),
+)
+
+enum class MissionPackageSideloadStatus {
+    NO_PACKAGE_FOUND,
+    IMPORTED,
+    IMPORT_FAILED,
+}

--- a/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
@@ -2,6 +2,7 @@ package com.cachekid.companion.kid
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
@@ -20,6 +21,7 @@ import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.geometry.LatLngBounds
+import org.maplibre.android.geometry.LatLngQuad
 import org.maplibre.android.style.layers.LineLayer
 import org.maplibre.android.style.layers.PropertyFactory.lineCap
 import org.maplibre.android.style.layers.PropertyFactory.lineColor
@@ -31,10 +33,17 @@ import org.maplibre.android.style.layers.PropertyFactory.iconSize
 import org.maplibre.android.style.layers.PropertyFactory.lineJoin
 import org.maplibre.android.style.layers.PropertyFactory.lineOpacity
 import org.maplibre.android.style.layers.PropertyFactory.lineWidth
+import org.maplibre.android.style.layers.PropertyFactory.rasterBrightnessMax
+import org.maplibre.android.style.layers.PropertyFactory.rasterBrightnessMin
+import org.maplibre.android.style.layers.PropertyFactory.rasterContrast
+import org.maplibre.android.style.layers.PropertyFactory.rasterOpacity
+import org.maplibre.android.style.layers.PropertyFactory.rasterSaturation
 import org.maplibre.android.style.layers.Property.LINE_CAP_ROUND
 import org.maplibre.android.style.layers.Property.LINE_JOIN_ROUND
+import org.maplibre.android.style.layers.RasterLayer
 import org.maplibre.android.style.layers.SymbolLayer
 import org.maplibre.android.style.sources.GeoJsonSource
+import org.maplibre.android.style.sources.ImageSource
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapView
@@ -43,12 +52,15 @@ import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.geojson.LineString
 import org.maplibre.geojson.Point
+import java.util.Base64
 
 class KidNativeMapController(
     context: Context,
     private val mapContainer: FrameLayout,
 ) {
     private companion object {
+        const val BASEMAP_SOURCE_ID = "cachekid-basemap-source"
+        const val BASEMAP_LAYER_ID = "cachekid-basemap-layer"
         const val TARGET_SOURCE_ID = "cachekid-target-source"
         const val PLAYER_SOURCE_ID = "cachekid-player-source"
         const val ROUTE_SOURCE_ID = "cachekid-route-source"
@@ -84,6 +96,7 @@ class KidNativeMapController(
     private var lastOrientationCommitAtMillis: Long = 0L
     private var displayedMissionId: String? = null
     private var displayedRouteStart: LatLng? = null
+    private var displayedBaseMapKey: String? = null
     private var lastCameraDebugInfo: CameraDebugInfo? = null
     private var viewportTopInsetPx: Float? = null
     private var viewportBottomInsetPx: Float? = null
@@ -157,6 +170,7 @@ class KidNativeMapController(
             lastOrientationCommitAtMillis = 0L
             displayedMissionId = null
             displayedRouteStart = null
+            displayedBaseMapKey = null
             previousCourseLocation = null
             currentCourseBearingDegrees = null
         } else if (missionChanged || displayedMissionId != mission.missionId || displayedRouteStart == null) {
@@ -164,6 +178,7 @@ class KidNativeMapController(
             lastOrientationCommitAtMillis = 0L
             displayedMissionId = mission.missionId
             displayedRouteStart = resolveDisplayRouteStart(mission)
+            displayedBaseMapKey = null
             previousCourseLocation = null
             currentCourseBearingDegrees = null
             lastZoneFitUsedStrict = true
@@ -300,6 +315,7 @@ class KidNativeMapController(
         val map = mapLibreMap ?: return
         val mission = currentMission ?: return
         val style = map.style ?: return
+        ensureBaseMapLayer(style, mission)
 
         val targetSource = style.getSourceAs<GeoJsonSource>(TARGET_SOURCE_ID) ?: return
         val playerSource = style.getSourceAs<GeoJsonSource>(PLAYER_SOURCE_ID) ?: return
@@ -408,6 +424,85 @@ class KidNativeMapController(
                 ),
             )
         }
+    }
+
+    private fun ensureBaseMapLayer(style: Style, mission: ActiveMission) {
+        val baseMap = mission.baseMap ?: mission.offlineMap ?: run {
+            if (style.getLayer(BASEMAP_LAYER_ID) != null) {
+                style.removeLayer(BASEMAP_LAYER_ID)
+            }
+            if (style.getSource(BASEMAP_SOURCE_ID) != null) {
+                style.removeSource(BASEMAP_SOURCE_ID)
+            }
+            displayedBaseMapKey = null
+            return
+        }
+        val basemapBitmap = bitmapFromMissionMap(baseMap) ?: run {
+            Log.w(CAMERA_LOG_TAG, "basemap decode failed mission=${mission.missionId} asset=${baseMap.assetPath}")
+            if (style.getLayer(BASEMAP_LAYER_ID) != null) {
+                style.removeLayer(BASEMAP_LAYER_ID)
+            }
+            if (style.getSource(BASEMAP_SOURCE_ID) != null) {
+                style.removeSource(BASEMAP_SOURCE_ID)
+            }
+            displayedBaseMapKey = null
+            return
+        }
+        val baseMapKey = listOf(
+            mission.missionId,
+            baseMap.assetPath,
+            baseMap.bounds.minLatitude,
+            baseMap.bounds.minLongitude,
+            baseMap.bounds.maxLatitude,
+            baseMap.bounds.maxLongitude,
+        ).joinToString("|")
+        if (displayedBaseMapKey == baseMapKey && style.getSource(BASEMAP_SOURCE_ID) != null) {
+            return
+        }
+
+        val baseMapQuad = LatLngQuad(
+            LatLng(baseMap.bounds.maxLatitude, baseMap.bounds.minLongitude),
+            LatLng(baseMap.bounds.maxLatitude, baseMap.bounds.maxLongitude),
+            LatLng(baseMap.bounds.minLatitude, baseMap.bounds.maxLongitude),
+            LatLng(baseMap.bounds.minLatitude, baseMap.bounds.minLongitude),
+        )
+        val existingSource = style.getSourceAs<ImageSource>(BASEMAP_SOURCE_ID)
+        if (existingSource == null) {
+            style.addSource(ImageSource(BASEMAP_SOURCE_ID, baseMapQuad, basemapBitmap))
+        } else {
+            existingSource.setCoordinates(baseMapQuad)
+            existingSource.setImage(basemapBitmap)
+        }
+        if (style.getLayer(BASEMAP_LAYER_ID) == null) {
+            style.addLayerAt(
+                RasterLayer(BASEMAP_LAYER_ID, BASEMAP_SOURCE_ID).withProperties(
+                    rasterSaturation(-1f),
+                    rasterContrast(0.08f),
+                    rasterBrightnessMin(0.28f),
+                    rasterBrightnessMax(1.02f),
+                    rasterOpacity(0.96f),
+                ),
+                2,
+            )
+        }
+        displayedBaseMapKey = baseMapKey
+        Log.d(
+            CAMERA_LOG_TAG,
+            "basemap-ready mission=${mission.missionId} asset=${baseMap.assetPath} bounds=${baseMap.bounds.minLatitude},${baseMap.bounds.minLongitude}|${baseMap.bounds.maxLatitude},${baseMap.bounds.maxLongitude}",
+        )
+    }
+
+    private fun bitmapFromMissionMap(map: com.cachekid.companion.host.mission.MissionOfflineMap): Bitmap? {
+        if (map.assetPath.endsWith(".png", ignoreCase = true)) {
+            val base64Payload = Regex("""data:image/png;base64,([A-Za-z0-9+/=]+)""")
+                .find(map.svgContent)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?: return null
+            val pngBytes = runCatching { Base64.getDecoder().decode(base64Payload) }.getOrNull() ?: return null
+            return BitmapFactory.decodeByteArray(pngBytes, 0, pngBytes.size)
+        }
+        return null
     }
 
     private fun buildTargetFeatures(targetPoint: Point): List<Feature> {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -310,6 +310,30 @@
             android:textColor="#5D5D55"
             android:textSize="12sp" />
 
+        <TextView
+            android:id="@+id/nativeSideloadHint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:textColor="#5D5D55"
+            android:textSize="12sp" />
+
+        <Button
+            android:id="@+id/nativeSideloadImportButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="ADB-Sideload laden" />
+
+        <TextView
+            android:id="@+id/nativeSideloadStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Kein adb-Sideload importiert."
+            android:textColor="#5D5D55"
+            android:textSize="12sp" />
+
         <Button
             android:id="@+id/nativeReceiveToggleButton"
             android:layout_width="match_parent"

--- a/app/src/test/java/com/cachekid/companion/host/mission/DeviceOfflineBaseMapRepositoryTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/DeviceOfflineBaseMapRepositoryTest.kt
@@ -120,4 +120,33 @@ class DeviceOfflineBaseMapRepositoryTest {
         assertNotNull(map)
         assertEquals("map.png", map?.assetPath)
     }
+
+    @Test
+    fun `repository prefers png asset even when metadata points to svg`() {
+        val baseDirectory = createTempDirectory("cachekid-offline-basemap-prefer-png").toFile()
+        val mapDirectory = File(baseDirectory, "celle").apply { mkdirs() }
+        File(mapDirectory, MissionPackageSchema.MAP_PNG_FILE).writeBytes(byteArrayOf(1, 2, 3, 4))
+        File(mapDirectory, MissionPackageSchema.MAP_SVG_FILE).writeText("<svg><path d=\"M 0 0 L 10 10\" /></svg>")
+        File(mapDirectory, MissionPackageSchema.MAP_METADATA_FILE).writeText(
+            """
+                {
+                  "assetPath": "map.svg",
+                  "bounds": {
+                    "minLatitude": 52.60,
+                    "minLongitude": 10.04,
+                    "maxLatitude": 52.65,
+                    "maxLongitude": 10.11
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val repository = DeviceOfflineBaseMapRepository(baseDirectory)
+
+        val map = repository.loadFor(MissionTarget(52.617, 10.0543))
+
+        assertNotNull(map)
+        assertEquals("map.png", map?.assetPath)
+        assertTrue(map?.svgContent?.contains("data:image/png;base64") == true)
+    }
 }

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSideloadImporterTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSideloadImporterTest.kt
@@ -1,0 +1,67 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class MissionPackageSideloadImporterTest {
+
+    private val writer = MissionPackageWriter()
+    private val zipCodec = MissionPackageZipCodec()
+    private val sideloadImporter = MissionPackageSideloadImporter()
+
+    @Test
+    fun `sideload importer imports latest zip package and archives it`() {
+        val tempRoot = createTempDirectory("cachekid-sideload-success").toFile()
+        val missionBaseDirectory = File(tempRoot, "missions")
+        val sideloadDirectory = File(tempRoot, "sideload").apply { mkdirs() }
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+        val zipFile = File(sideloadDirectory, "mission.zip")
+        zipFile.writeBytes(zipCodec.encode(missionPackage))
+
+        val result = sideloadImporter.importLatest(
+            missionBaseDirectory = missionBaseDirectory,
+            candidateDirectories = listOf(sideloadDirectory),
+        )
+
+        assertEquals(MissionPackageSideloadStatus.IMPORTED, result.status)
+        assertTrue(requireNotNull(result.importResult).isSuccess)
+        assertFalse(zipFile.exists())
+        assertTrue(File(sideloadDirectory, "imported/mission.zip").exists())
+        assertTrue(File(missionBaseDirectory, "${missionPackage.missionId}/mission.json").exists())
+    }
+
+    @Test
+    fun `sideload importer archives invalid zip package as failed`() {
+        val tempRoot = createTempDirectory("cachekid-sideload-failure").toFile()
+        val missionBaseDirectory = File(tempRoot, "missions")
+        val sideloadDirectory = File(tempRoot, "sideload").apply { mkdirs() }
+        val zipFile = File(sideloadDirectory, "broken.zip")
+        zipFile.writeText("not-a-valid-zip")
+
+        val result = sideloadImporter.importLatest(
+            missionBaseDirectory = missionBaseDirectory,
+            candidateDirectories = listOf(sideloadDirectory),
+        )
+
+        assertEquals(MissionPackageSideloadStatus.IMPORT_FAILED, result.status)
+        assertTrue(result.errors.isNotEmpty())
+        assertFalse(zipFile.exists())
+        assertTrue(File(sideloadDirectory, "failed/broken.zip").exists())
+        assertTrue(File(sideloadDirectory, "failed/broken.zip.error.txt").exists())
+    }
+
+    private fun validDraft(): MissionDraft {
+        return MissionDraft(
+            cacheCode = "GC12345",
+            sourceTitle = "Old Oak Cache",
+            childTitle = "Der Schatz im Wald",
+            summary = "Folge der Karte bis zum grossen X.",
+            target = MissionTarget(52.520008, 13.404954),
+            sourceApp = "geocaching",
+        )
+    }
+}


### PR DESCRIPTION
Closes #32

## Behavior
- adds an adb-friendly mission sideload path on the kid device
- imports sideloaded mission ZIPs through the normal package importer
- surfaces a native sideload action/status in the receive panel
- renders the currently available device basemap as a native overlay under route/O/X

## Refactors
- extracts mission sideload import into a dedicated host.mission service
- keeps the current device-basemap overlay as an explicit transition step, not the final offline map architecture

## Risks
- local Gradle tests could not be run in this terminal because no Java runtime is installed
- the basemap overlay still reflects the current static local basemap assets and is not the full offline map solution tracked in #33
