### PR TITLE
[codex] Define real offline kid map package target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ captures/
 # OS files
 .DS_Store
 
+# Python tooling
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ The intended map architecture is:
 
 Mission-specific generated map assets may still exist as prototype or fallback code, but they are not the long-term architecture.
 
+The concrete offline-map target is documented in `docs/offline-map-architecture.md`.
+Real kid-device offline maps are installed packages containing `offline-map.json`, `map.pmtiles`, and `style.json`.
+Bundled `map.png` / `map.svg` basemaps are legacy prototype assets and must not be treated as proof that the device has a real offline map installed.
+
 ### Kid map presentation
 
 The child map should stay:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Mission-specific generated map assets may still exist as prototype or fallback c
 The concrete offline-map target is documented in `docs/offline-map-architecture.md`.
 Real kid-device offline maps are installed packages containing `offline-map.json`, `map.pmtiles`, and `style.json`.
 Bundled `map.png` / `map.svg` basemaps are legacy prototype assets and must not be treated as proof that the device has a real offline map installed.
+For development, `tools/build_offline_map_package.py` can build a small real PMTiles sideload package for a test region.
 
 ### Kid map presentation
 

--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -50,6 +50,8 @@ import com.cachekid.companion.host.mission.HostMissionBuilderPresenter
 import com.cachekid.companion.host.mission.MissionOfflineMapService
 import com.cachekid.companion.host.mission.MissionTarget
 import com.cachekid.companion.host.mission.OfflineMissionMapComposer
+import com.cachekid.companion.host.mission.OfflineBaseMapPackageSideloadImporter
+import com.cachekid.companion.host.mission.OfflineBaseMapPackageSideloadStatus
 import com.cachekid.companion.host.mission.WalkingRouteWaypointService
 import com.cachekid.companion.host.resolution.CacheResolutionResult
 import com.cachekid.companion.host.resolution.AndroidGeocachingSessionStore
@@ -81,6 +83,7 @@ class MainActivity : AppCompatActivity() {
     private val missionPackageWriter = MissionPackageWriter()
     private val missionPackageFileStore = MissionPackageFileStore()
     private val missionPackageSideloadImporter = MissionPackageSideloadImporter()
+    private val offlineBaseMapPackageSideloadImporter = OfflineBaseMapPackageSideloadImporter()
     private val injectedNavigationInputImporter = InjectedNavigationInputFileImporter()
     private val missionPackageSenderClient = MissionPackageSenderClient()
     private val missionTargetParser = MissionTargetParser()
@@ -103,6 +106,7 @@ class MainActivity : AppCompatActivity() {
     private var sideloadStatusText: String = "Kein adb-Sideload importiert."
     private var navigationInputStatusText: String = "Keine adb-Navigation importiert."
     private var sideloadImportRunning: Boolean = false
+    private var offlineBaseMapImportRunning: Boolean = false
     private var navigationInputImportRunning: Boolean = false
     private var importSessionId: Long = 0L
     private var latestLocation: Location? = null
@@ -296,6 +300,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        importPendingOfflineBaseMap(showToast = false)
         activeMission = loadActiveMission()
         importPendingSideloadMission(showToast = activeMission == null)
         importPendingInjectedNavigationInput(showToast = false)
@@ -320,6 +325,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         kidNativeMapController.onResume()
+        importPendingOfflineBaseMap(showToast = false)
         importPendingSideloadMission(showToast = activeMission == null)
         importPendingInjectedNavigationInput(showToast = activeMission != null)
         if (hasLocationPermissions()) {
@@ -1013,6 +1019,69 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun importPendingOfflineBaseMap(showToast: Boolean) {
+        if (offlineBaseMapImportRunning) {
+            return
+        }
+        offlineBaseMapImportRunning = true
+        lifecycleScope.launch {
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    offlineBaseMapPackageSideloadImporter.importLatest(
+                        offlineMapBaseDirectory = File(filesDir, OFFLINE_BASEMAP_DIRECTORY),
+                        candidateDirectories = offlineBaseMapSideloadDirectories(),
+                    )
+                }
+
+                when (result.status) {
+                    OfflineBaseMapPackageSideloadStatus.NO_PACKAGE_FOUND -> Unit
+
+                    OfflineBaseMapPackageSideloadStatus.IMPORTED -> {
+                        deviceOfflineBaseMapRepository = DeviceOfflineBaseMapRepository(
+                            File(filesDir, OFFLINE_BASEMAP_DIRECTORY),
+                        )
+                        activeMission = activeMission?.let(::attachDeviceBaseMap)
+                        refreshNativeMap()
+                        Log.d(
+                            RESOLVER_LOG_TAG,
+                            "offline-basemap-imported source=${result.sourceFile?.absolutePath} archived=${result.archivedFile?.absolutePath} package=${result.installResult?.offlinePackage?.id}",
+                        )
+                        if (showToast) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                result.message,
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    }
+
+                    OfflineBaseMapPackageSideloadStatus.IMPORT_FAILED -> {
+                        Log.w(
+                            RESOLVER_LOG_TAG,
+                            "offline-basemap-import-failed source=${result.sourceFile?.absolutePath} archived=${result.archivedFile?.absolutePath} errors=${result.errors.joinToString(" | ")}",
+                        )
+                        if (showToast) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                result.message,
+                                Toast.LENGTH_LONG,
+                            ).show()
+                        }
+                    }
+                }
+            } finally {
+                offlineBaseMapImportRunning = false
+            }
+        }
+    }
+
+    private fun offlineBaseMapSideloadDirectories(): List<File> {
+        val internalDirectory = File(filesDir, OFFLINE_MAP_SIDELOAD_DIRECTORY).apply { mkdirs() }
+        val externalDirectory = getExternalFilesDir(null)
+            ?.let { File(it, OFFLINE_MAP_SIDELOAD_DIRECTORY).apply { mkdirs() } }
+        return listOfNotNull(externalDirectory, internalDirectory)
+    }
+
     private fun sideloadDirectories(): List<File> {
         val internalDirectory = File(filesDir, MISSION_SIDELOAD_DIRECTORY).apply { mkdirs() }
         val externalDirectory = getExternalFilesDir(null)
@@ -1299,6 +1368,7 @@ class MainActivity : AppCompatActivity() {
         const val MISSION_STORAGE_DIRECTORY = "missions"
         const val MISSION_SIDELOAD_DIRECTORY = "mission-sideload"
         const val NAVIGATION_INPUT_SIDELOAD_DIRECTORY = "navigation-input-sideload"
+        const val OFFLINE_MAP_SIDELOAD_DIRECTORY = "offline-map-sideload"
         const val OFFLINE_BASEMAP_DIRECTORY = "offline-basemaps"
         const val DEFAULT_RECEIVER_HOST = "127.0.0.1"
         const val DEFAULT_RECEIVER_PORT = 8765

--- a/app/src/main/java/com/cachekid/companion/MainActivity.kt
+++ b/app/src/main/java/com/cachekid/companion/MainActivity.kt
@@ -1220,6 +1220,13 @@ class MainActivity : AppCompatActivity() {
     private fun attachDeviceBaseMap(mission: ActiveMission): ActiveMission {
         return mission.copy(
             baseMap = deviceOfflineBaseMapRepository.loadFor(mission.target),
+            offlineBaseMapPackage = offlineBaseMapPackageRepository().findCovering(mission.target),
+        )
+    }
+
+    private fun offlineBaseMapPackageRepository(): com.cachekid.companion.host.mission.OfflineBaseMapPackageRepository {
+        return com.cachekid.companion.host.mission.OfflineBaseMapPackageRepository(
+            File(filesDir, OFFLINE_BASEMAP_DIRECTORY),
         )
     }
 
@@ -1354,11 +1361,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun describeBaseMapStatus(mission: ActiveMission?): String {
         val currentMission = mission ?: return "Lokale Basemap: keine aktive Mission."
-        val baseMap = currentMission.baseMap
-        return if (baseMap != null) {
-            "Lokale Basemap gefunden."
+        val offlinePackage = currentMission.offlineBaseMapPackage
+        return if (offlinePackage != null) {
+            "Offline-Karte gefunden: ${offlinePackage.displayName}."
         } else {
-            "Keine lokale Basemap gefunden."
+            "Keine echte Offline-Karte fuer dieses Ziel gefunden."
         }
     }
 

--- a/app/src/main/java/com/cachekid/companion/host/mission/ActiveMission.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/ActiveMission.kt
@@ -12,4 +12,5 @@ data class ActiveMission(
     val sourceApp: String? = null,
     val offlineMap: MissionOfflineMap? = null,
     val baseMap: MissionOfflineMap? = null,
+    val offlineBaseMapPackage: OfflineBaseMapPackage? = null,
 )

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSchema.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSchema.kt
@@ -8,6 +8,9 @@ object MissionPackageSchema {
     const val MAP_METADATA_FILE = "map-meta.json"
     const val MAP_SVG_FILE = "map.svg"
     const val MAP_PNG_FILE = "map.png"
+    const val OFFLINE_MAP_METADATA_FILE = "offline-map.json"
+    const val OFFLINE_MAP_PMTILES_FILE = "map.pmtiles"
+    const val OFFLINE_MAP_STYLE_FILE = "style.json"
 
     val requiredCoreFiles: List<String> = listOf(
         INTEGRITY_FILE,

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackage.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackage.kt
@@ -1,5 +1,7 @@
 package com.cachekid.companion.host.mission
 
+import java.io.File
+
 data class OfflineBaseMapPackage(
     val id: String,
     val displayName: String,
@@ -8,6 +10,7 @@ data class OfflineBaseMapPackage(
     val bounds: MissionMapBounds,
     val tileAssetPath: String,
     val styleAssetPath: String,
+    val packageDirectory: File,
     val minZoom: Int,
     val maxZoom: Int,
     val attribution: String?,

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackage.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackage.kt
@@ -1,0 +1,26 @@
+package com.cachekid.companion.host.mission
+
+data class OfflineBaseMapPackage(
+    val id: String,
+    val displayName: String,
+    val version: String,
+    val format: OfflineBaseMapPackageFormat,
+    val bounds: MissionMapBounds,
+    val tileAssetPath: String,
+    val styleAssetPath: String,
+    val minZoom: Int,
+    val maxZoom: Int,
+    val attribution: String?,
+) {
+    fun covers(target: MissionTarget): Boolean = bounds.contains(target)
+}
+
+enum class OfflineBaseMapPackageFormat(val metadataValue: String) {
+    PMTILES_VECTOR("pmtiles-vector");
+
+    companion object {
+        fun fromMetadataValue(value: String?): OfflineBaseMapPackageFormat? {
+            return entries.firstOrNull { it.metadataValue == value }
+        }
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageManifestReader.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageManifestReader.kt
@@ -1,8 +1,10 @@
 package com.cachekid.companion.host.mission
 
+import java.io.File
+
 class OfflineBaseMapPackageManifestReader {
 
-    fun read(metadata: String, fallbackId: String): OfflineBaseMapPackage? {
+    fun read(metadata: String, fallbackId: String, packageDirectory: File): OfflineBaseMapPackage? {
         val packageId = readPackageId(metadata, fallbackId) ?: return null
         val format = OfflineBaseMapPackageFormat.fromMetadataValue(extractStringValue(metadata, "format"))
             ?: return null
@@ -23,6 +25,7 @@ class OfflineBaseMapPackageManifestReader {
                 ?: MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE,
             styleAssetPath = extractStringValue(metadata, "styleAssetPath")
                 ?: MissionPackageSchema.OFFLINE_MAP_STYLE_FILE,
+            packageDirectory = packageDirectory,
             minZoom = extractIntValue(metadata, "minZoom") ?: 0,
             maxZoom = extractIntValue(metadata, "maxZoom") ?: 14,
             attribution = extractStringValue(metadata, "attribution"),

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageManifestReader.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageManifestReader.kt
@@ -1,0 +1,85 @@
+package com.cachekid.companion.host.mission
+
+class OfflineBaseMapPackageManifestReader {
+
+    fun read(metadata: String, fallbackId: String): OfflineBaseMapPackage? {
+        val packageId = readPackageId(metadata, fallbackId) ?: return null
+        val format = OfflineBaseMapPackageFormat.fromMetadataValue(extractStringValue(metadata, "format"))
+            ?: return null
+        val boundsJson = extractObject(metadata, "bounds") ?: return null
+
+        return OfflineBaseMapPackage(
+            id = packageId,
+            displayName = extractStringValue(metadata, "displayName") ?: packageId,
+            version = extractStringValue(metadata, "version") ?: "0",
+            format = format,
+            bounds = MissionMapBounds(
+                minLatitude = extractDoubleValue(boundsJson, "minLatitude") ?: return null,
+                minLongitude = extractDoubleValue(boundsJson, "minLongitude") ?: return null,
+                maxLatitude = extractDoubleValue(boundsJson, "maxLatitude") ?: return null,
+                maxLongitude = extractDoubleValue(boundsJson, "maxLongitude") ?: return null,
+            ),
+            tileAssetPath = extractStringValue(metadata, "tileAssetPath")
+                ?: MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE,
+            styleAssetPath = extractStringValue(metadata, "styleAssetPath")
+                ?: MissionPackageSchema.OFFLINE_MAP_STYLE_FILE,
+            minZoom = extractIntValue(metadata, "minZoom") ?: 0,
+            maxZoom = extractIntValue(metadata, "maxZoom") ?: 14,
+            attribution = extractStringValue(metadata, "attribution"),
+        )
+    }
+
+    fun readPackageId(metadata: String, fallbackId: String): String? {
+        return sanitizePackageId(extractStringValue(metadata, "id") ?: fallbackId)
+    }
+
+    private fun sanitizePackageId(rawId: String): String? {
+        val normalized = rawId.trim()
+        if (normalized.isBlank() || normalized.contains("/") || normalized.contains("\\")) {
+            return null
+        }
+        return normalized.takeIf { Regex("""[a-zA-Z0-9._-]+""").matches(it) }
+    }
+
+    private fun extractStringValue(json: String, key: String): String? {
+        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
+        return regex.find(json)?.groupValues?.getOrNull(1)
+    }
+
+    private fun extractDoubleValue(json: String, key: String): Double? {
+        val regex = Regex(""""$key"\s*:\s*(-?\d+(?:\.\d+)?)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toDoubleOrNull()
+    }
+
+    private fun extractIntValue(json: String, key: String): Int? {
+        val regex = Regex(""""$key"\s*:\s*(\d+)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun extractObject(json: String, key: String): String? {
+        val keyIndex = json.indexOf(""""$key"""")
+        if (keyIndex < 0) {
+            return null
+        }
+
+        val objectStart = json.indexOf('{', startIndex = keyIndex)
+        if (objectStart < 0) {
+            return null
+        }
+
+        var depth = 0
+        for (index in objectStart until json.length) {
+            when (json[index]) {
+                '{' -> depth += 1
+                '}' -> {
+                    depth -= 1
+                    if (depth == 0) {
+                        return json.substring(objectStart, index + 1)
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
@@ -1,0 +1,103 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+class OfflineBaseMapPackageRepository(
+    private val baseDirectory: File,
+) {
+
+    fun listInstalled(): List<OfflineBaseMapPackage> {
+        if (!baseDirectory.exists() || !baseDirectory.isDirectory) {
+            return emptyList()
+        }
+
+        return baseDirectory.listFiles()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { packageDirectory -> loadPackage(packageDirectory) }
+            ?.sortedBy { it.displayName }
+            .orEmpty()
+    }
+
+    fun findCovering(target: MissionTarget): OfflineBaseMapPackage? {
+        return listInstalled().firstOrNull { offlinePackage -> offlinePackage.covers(target) }
+    }
+
+    private fun loadPackage(packageDirectory: File): OfflineBaseMapPackage? {
+        val metadata = File(packageDirectory, MissionPackageSchema.OFFLINE_MAP_METADATA_FILE)
+            .takeIf { it.exists() && it.isFile }
+            ?.readText()
+            ?: return null
+
+        val format = OfflineBaseMapPackageFormat.fromMetadataValue(extractStringValue(metadata, "format"))
+            ?: return null
+        val tileAssetPath = extractStringValue(metadata, "tileAssetPath")
+            ?: MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE
+        val styleAssetPath = extractStringValue(metadata, "styleAssetPath")
+            ?: MissionPackageSchema.OFFLINE_MAP_STYLE_FILE
+        val boundsJson = extractObject(metadata, "bounds") ?: return null
+
+        if (!File(packageDirectory, tileAssetPath).isFile || !File(packageDirectory, styleAssetPath).isFile) {
+            return null
+        }
+
+        return OfflineBaseMapPackage(
+            id = extractStringValue(metadata, "id") ?: packageDirectory.name,
+            displayName = extractStringValue(metadata, "displayName") ?: packageDirectory.name,
+            version = extractStringValue(metadata, "version") ?: "0",
+            format = format,
+            bounds = MissionMapBounds(
+                minLatitude = extractDoubleValue(boundsJson, "minLatitude") ?: return null,
+                minLongitude = extractDoubleValue(boundsJson, "minLongitude") ?: return null,
+                maxLatitude = extractDoubleValue(boundsJson, "maxLatitude") ?: return null,
+                maxLongitude = extractDoubleValue(boundsJson, "maxLongitude") ?: return null,
+            ),
+            tileAssetPath = tileAssetPath,
+            styleAssetPath = styleAssetPath,
+            minZoom = extractIntValue(metadata, "minZoom") ?: 0,
+            maxZoom = extractIntValue(metadata, "maxZoom") ?: 14,
+            attribution = extractStringValue(metadata, "attribution"),
+        )
+    }
+
+    private fun extractStringValue(json: String, key: String): String? {
+        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
+        return regex.find(json)?.groupValues?.getOrNull(1)
+    }
+
+    private fun extractDoubleValue(json: String, key: String): Double? {
+        val regex = Regex(""""$key"\s*:\s*(-?\d+(?:\.\d+)?)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toDoubleOrNull()
+    }
+
+    private fun extractIntValue(json: String, key: String): Int? {
+        val regex = Regex(""""$key"\s*:\s*(\d+)""")
+        return regex.find(json)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    }
+
+    private fun extractObject(json: String, key: String): String? {
+        val keyIndex = json.indexOf(""""$key"""")
+        if (keyIndex < 0) {
+            return null
+        }
+
+        val objectStart = json.indexOf('{', startIndex = keyIndex)
+        if (objectStart < 0) {
+            return null
+        }
+
+        var depth = 0
+        for (index in objectStart until json.length) {
+            when (json[index]) {
+                '{' -> depth += 1
+                '}' -> {
+                    depth -= 1
+                    if (depth == 0) {
+                        return json.substring(objectStart, index + 1)
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
@@ -4,6 +4,7 @@ import java.io.File
 
 class OfflineBaseMapPackageRepository(
     private val baseDirectory: File,
+    private val manifestReader: OfflineBaseMapPackageManifestReader = OfflineBaseMapPackageManifestReader(),
 ) {
 
     fun listInstalled(): List<OfflineBaseMapPackage> {
@@ -28,76 +29,17 @@ class OfflineBaseMapPackageRepository(
             ?.readText()
             ?: return null
 
-        val format = OfflineBaseMapPackageFormat.fromMetadataValue(extractStringValue(metadata, "format"))
+        val packageId = manifestReader.readPackageId(metadata, fallbackId = packageDirectory.name)
             ?: return null
-        val tileAssetPath = extractStringValue(metadata, "tileAssetPath")
-            ?: MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE
-        val styleAssetPath = extractStringValue(metadata, "styleAssetPath")
-            ?: MissionPackageSchema.OFFLINE_MAP_STYLE_FILE
-        val boundsJson = extractObject(metadata, "bounds") ?: return null
+        val offlinePackage = manifestReader.read(metadata, packageId) ?: return null
 
-        if (!File(packageDirectory, tileAssetPath).isFile || !File(packageDirectory, styleAssetPath).isFile) {
+        if (
+            !File(packageDirectory, offlinePackage.tileAssetPath).isFile ||
+            !File(packageDirectory, offlinePackage.styleAssetPath).isFile
+        ) {
             return null
         }
 
-        return OfflineBaseMapPackage(
-            id = extractStringValue(metadata, "id") ?: packageDirectory.name,
-            displayName = extractStringValue(metadata, "displayName") ?: packageDirectory.name,
-            version = extractStringValue(metadata, "version") ?: "0",
-            format = format,
-            bounds = MissionMapBounds(
-                minLatitude = extractDoubleValue(boundsJson, "minLatitude") ?: return null,
-                minLongitude = extractDoubleValue(boundsJson, "minLongitude") ?: return null,
-                maxLatitude = extractDoubleValue(boundsJson, "maxLatitude") ?: return null,
-                maxLongitude = extractDoubleValue(boundsJson, "maxLongitude") ?: return null,
-            ),
-            tileAssetPath = tileAssetPath,
-            styleAssetPath = styleAssetPath,
-            minZoom = extractIntValue(metadata, "minZoom") ?: 0,
-            maxZoom = extractIntValue(metadata, "maxZoom") ?: 14,
-            attribution = extractStringValue(metadata, "attribution"),
-        )
-    }
-
-    private fun extractStringValue(json: String, key: String): String? {
-        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
-        return regex.find(json)?.groupValues?.getOrNull(1)
-    }
-
-    private fun extractDoubleValue(json: String, key: String): Double? {
-        val regex = Regex(""""$key"\s*:\s*(-?\d+(?:\.\d+)?)""")
-        return regex.find(json)?.groupValues?.getOrNull(1)?.toDoubleOrNull()
-    }
-
-    private fun extractIntValue(json: String, key: String): Int? {
-        val regex = Regex(""""$key"\s*:\s*(\d+)""")
-        return regex.find(json)?.groupValues?.getOrNull(1)?.toIntOrNull()
-    }
-
-    private fun extractObject(json: String, key: String): String? {
-        val keyIndex = json.indexOf(""""$key"""")
-        if (keyIndex < 0) {
-            return null
-        }
-
-        val objectStart = json.indexOf('{', startIndex = keyIndex)
-        if (objectStart < 0) {
-            return null
-        }
-
-        var depth = 0
-        for (index in objectStart until json.length) {
-            when (json[index]) {
-                '{' -> depth += 1
-                '}' -> {
-                    depth -= 1
-                    if (depth == 0) {
-                        return json.substring(objectStart, index + 1)
-                    }
-                }
-            }
-        }
-
-        return null
+        return offlinePackage
     }
 }

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepository.kt
@@ -31,7 +31,7 @@ class OfflineBaseMapPackageRepository(
 
         val packageId = manifestReader.readPackageId(metadata, fallbackId = packageDirectory.name)
             ?: return null
-        val offlinePackage = manifestReader.read(metadata, packageId) ?: return null
+        val offlinePackage = manifestReader.read(metadata, packageId, packageDirectory) ?: return null
 
         if (
             !File(packageDirectory, offlinePackage.tileAssetPath).isFile ||

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageSideloadImporter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageSideloadImporter.kt
@@ -1,0 +1,135 @@
+package com.cachekid.companion.host.mission
+
+import java.io.File
+
+class OfflineBaseMapPackageSideloadImporter(
+    private val installer: OfflineBaseMapPackageZipInstaller = OfflineBaseMapPackageZipInstaller(),
+) {
+
+    fun importLatest(
+        offlineMapBaseDirectory: File,
+        candidateDirectories: List<File>,
+    ): OfflineBaseMapPackageSideloadResult {
+        val normalizedDirectories = candidateDirectories.distinctBy { it.absolutePath }
+        val latestPackage = normalizedDirectories
+            .asSequence()
+            .filter { it.exists() && it.isDirectory }
+            .flatMap { directory ->
+                directory.listFiles()
+                    .orEmpty()
+                    .asSequence()
+                    .filter { file -> file.isFile && file.extension.equals("zip", ignoreCase = true) }
+            }
+            .maxByOrNull { it.lastModified() }
+
+        if (latestPackage == null) {
+            return OfflineBaseMapPackageSideloadResult(
+                status = OfflineBaseMapPackageSideloadStatus.NO_PACKAGE_FOUND,
+                message = "Kein Offline-Kartenpaket gefunden.",
+                searchedDirectories = normalizedDirectories,
+            )
+        }
+
+        val zipBytes = runCatching { latestPackage.readBytes() }.getOrElse { error ->
+            val archivedFile = archive(latestPackage, FAILED_DIRECTORY_NAME)
+            val errorReport = writeErrorReport(archivedFile ?: latestPackage, error.message ?: "Unbekannter Lesefehler.")
+            return OfflineBaseMapPackageSideloadResult(
+                status = OfflineBaseMapPackageSideloadStatus.IMPORT_FAILED,
+                sourceFile = latestPackage,
+                archivedFile = archivedFile,
+                errorReportFile = errorReport,
+                message = "Offline-Kartenpaket konnte nicht gelesen werden: ${latestPackage.name}",
+                errors = listOf(error.message ?: "Unbekannter Lesefehler."),
+                searchedDirectories = normalizedDirectories,
+            )
+        }
+
+        val installResult = installer.install(offlineMapBaseDirectory, zipBytes)
+        return if (installResult.isSuccess) {
+            OfflineBaseMapPackageSideloadResult(
+                status = OfflineBaseMapPackageSideloadStatus.IMPORTED,
+                sourceFile = latestPackage,
+                archivedFile = archive(latestPackage, IMPORTED_DIRECTORY_NAME),
+                installResult = installResult,
+                message = "Offline-Karte importiert: ${installResult.offlinePackage?.displayName}",
+                searchedDirectories = normalizedDirectories,
+            )
+        } else {
+            val archivedFile = archive(latestPackage, FAILED_DIRECTORY_NAME)
+            val errorReport = writeErrorReport(archivedFile ?: latestPackage, installResult.errors.joinToString("\n"))
+            OfflineBaseMapPackageSideloadResult(
+                status = OfflineBaseMapPackageSideloadStatus.IMPORT_FAILED,
+                sourceFile = latestPackage,
+                archivedFile = archivedFile,
+                errorReportFile = errorReport,
+                installResult = installResult,
+                message = "Offline-Kartenimport fehlgeschlagen: ${latestPackage.name}",
+                errors = installResult.errors,
+                searchedDirectories = normalizedDirectories,
+            )
+        }
+    }
+
+    private fun archive(sourceFile: File, archiveDirectoryName: String): File? {
+        val archiveDirectory = File(sourceFile.parentFile, archiveDirectoryName)
+        archiveDirectory.mkdirs()
+        val archivedFile = uniqueArchiveFile(archiveDirectory, sourceFile)
+        if (sourceFile.renameTo(archivedFile)) {
+            return archivedFile
+        }
+
+        return runCatching {
+            sourceFile.copyTo(target = archivedFile, overwrite = false)
+            if (!sourceFile.delete()) {
+                archivedFile.delete()
+                null
+            } else {
+                archivedFile
+            }
+        }.getOrNull()
+    }
+
+    private fun uniqueArchiveFile(archiveDirectory: File, sourceFile: File): File {
+        val baseName = sourceFile.nameWithoutExtension
+        val extension = sourceFile.extension.takeIf { it.isNotBlank() }?.let { ".$it" }.orEmpty()
+        var attempt = 0
+        while (true) {
+            val suffix = if (attempt == 0) "" else "-$attempt"
+            val candidate = File(archiveDirectory, "$baseName$suffix$extension")
+            if (!candidate.exists()) {
+                return candidate
+            }
+            attempt += 1
+        }
+    }
+
+    private fun writeErrorReport(referenceFile: File, errorText: String): File? {
+        val reportFile = File(referenceFile.parentFile, "${referenceFile.name}.error.txt")
+        return runCatching {
+            reportFile.writeText(errorText)
+            reportFile
+        }.getOrNull()
+    }
+
+    companion object {
+        const val IMPORTED_DIRECTORY_NAME = "imported"
+        const val FAILED_DIRECTORY_NAME = "failed"
+    }
+}
+
+data class OfflineBaseMapPackageSideloadResult(
+    val status: OfflineBaseMapPackageSideloadStatus,
+    val sourceFile: File? = null,
+    val archivedFile: File? = null,
+    val errorReportFile: File? = null,
+    val installResult: OfflineBaseMapPackageInstallResult? = null,
+    val message: String,
+    val errors: List<String> = emptyList(),
+    val searchedDirectories: List<File> = emptyList(),
+)
+
+enum class OfflineBaseMapPackageSideloadStatus {
+    NO_PACKAGE_FOUND,
+    IMPORTED,
+    IMPORT_FAILED,
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstaller.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstaller.kt
@@ -28,7 +28,8 @@ class OfflineBaseMapPackageZipInstaller(
                 packageDirectory = null,
                 errors = listOf("Offline map package id is missing or invalid."),
             )
-        val offlinePackage = manifestReader.read(metadata, fallbackId = packageId)
+        val packageDirectory = File(baseDirectory, packageId)
+        val offlinePackage = manifestReader.read(metadata, fallbackId = packageId, packageDirectory = packageDirectory)
             ?: return OfflineBaseMapPackageInstallResult(
                 offlinePackage = null,
                 packageDirectory = null,
@@ -60,7 +61,6 @@ class OfflineBaseMapPackageZipInstaller(
             )
         }
 
-        val packageDirectory = File(baseDirectory, packageId)
         val temporaryDirectory = File(baseDirectory, "$packageId.tmp").apply {
             deleteRecursively()
         }

--- a/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstaller.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstaller.kt
@@ -1,0 +1,137 @@
+package com.cachekid.companion.host.mission
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+
+class OfflineBaseMapPackageZipInstaller(
+    private val manifestReader: OfflineBaseMapPackageManifestReader = OfflineBaseMapPackageManifestReader(),
+) {
+
+    fun install(baseDirectory: File, zipBytes: ByteArray): OfflineBaseMapPackageInstallResult {
+        val zipFiles = decodeZip(zipBytes).getOrElse {
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = null,
+                packageDirectory = null,
+                errors = listOf("Offline map ZIP could not be decoded."),
+            )
+        }
+        val metadata = zipFiles[MissionPackageSchema.OFFLINE_MAP_METADATA_FILE]?.toString(Charsets.UTF_8)
+            ?: return OfflineBaseMapPackageInstallResult(
+                offlinePackage = null,
+                packageDirectory = null,
+                errors = listOf("Offline map package is missing ${MissionPackageSchema.OFFLINE_MAP_METADATA_FILE}."),
+            )
+        val packageId = manifestReader.readPackageId(metadata, fallbackId = "")
+            ?: return OfflineBaseMapPackageInstallResult(
+                offlinePackage = null,
+                packageDirectory = null,
+                errors = listOf("Offline map package id is missing or invalid."),
+            )
+        val offlinePackage = manifestReader.read(metadata, fallbackId = packageId)
+            ?: return OfflineBaseMapPackageInstallResult(
+                offlinePackage = null,
+                packageDirectory = null,
+                errors = listOf("Offline map manifest is invalid."),
+            )
+
+        val missingFiles = listOf(offlinePackage.tileAssetPath, offlinePackage.styleAssetPath)
+            .filterNot { path -> zipFiles.containsKey(path) }
+        if (missingFiles.isNotEmpty()) {
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = offlinePackage,
+                packageDirectory = null,
+                errors = listOf("Offline map package is missing files: ${missingFiles.sorted().joinToString(", ")}"),
+            )
+        }
+
+        if (baseDirectory.exists() && !baseDirectory.isDirectory) {
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = offlinePackage,
+                packageDirectory = null,
+                errors = listOf("Offline map storage path is not a directory."),
+            )
+        }
+        if (!baseDirectory.exists() && !baseDirectory.mkdirs()) {
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = offlinePackage,
+                packageDirectory = null,
+                errors = listOf("Offline map storage directory could not be created."),
+            )
+        }
+
+        val packageDirectory = File(baseDirectory, packageId)
+        val temporaryDirectory = File(baseDirectory, "$packageId.tmp").apply {
+            deleteRecursively()
+        }
+        if (!temporaryDirectory.mkdirs()) {
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = offlinePackage,
+                packageDirectory = null,
+                errors = listOf("Offline map temporary directory could not be created."),
+            )
+        }
+
+        val requiredPaths = setOf(
+            MissionPackageSchema.OFFLINE_MAP_METADATA_FILE,
+            offlinePackage.tileAssetPath,
+            offlinePackage.styleAssetPath,
+        )
+        requiredPaths.forEach { path ->
+            val outputFile = File(temporaryDirectory, path)
+            outputFile.parentFile?.mkdirs()
+            outputFile.writeBytes(requireNotNull(zipFiles[path]))
+        }
+
+        packageDirectory.deleteRecursively()
+        if (!temporaryDirectory.renameTo(packageDirectory)) {
+            temporaryDirectory.deleteRecursively()
+            return OfflineBaseMapPackageInstallResult(
+                offlinePackage = offlinePackage,
+                packageDirectory = null,
+                errors = listOf("Offline map package could not be installed."),
+            )
+        }
+
+        return OfflineBaseMapPackageInstallResult(
+            offlinePackage = offlinePackage,
+            packageDirectory = packageDirectory,
+            errors = emptyList(),
+        )
+    }
+
+    private fun decodeZip(zipBytes: ByteArray): Result<Map<String, ByteArray>> {
+        return runCatching {
+            val files = linkedMapOf<String, ByteArray>()
+            ZipInputStream(ByteArrayInputStream(zipBytes)).use { zipInput ->
+                var entry = zipInput.nextEntry
+                while (entry != null) {
+                    if (!entry.isDirectory) {
+                        val normalizedName = normalizeEntryName(entry.name)
+                        files[normalizedName] = zipInput.readBytes()
+                    }
+                    zipInput.closeEntry()
+                    entry = zipInput.nextEntry
+                }
+            }
+            files.toSortedMap()
+        }
+    }
+
+    private fun normalizeEntryName(entryName: String): String {
+        val normalized = entryName.replace('\\', '/').trim('/')
+        require(normalized.isNotBlank()) { "Blank ZIP entry name." }
+        require(normalized.split('/').none { segment -> segment.isBlank() || segment == ".." }) {
+            "Unsafe ZIP entry path."
+        }
+        return normalized
+    }
+}
+
+data class OfflineBaseMapPackageInstallResult(
+    val offlinePackage: OfflineBaseMapPackage?,
+    val packageDirectory: File?,
+    val errors: List<String>,
+) {
+    val isSuccess: Boolean = errors.isEmpty() && offlinePackage != null && packageDirectory != null
+}

--- a/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
@@ -2,7 +2,6 @@ package com.cachekid.companion.kid
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
@@ -14,14 +13,12 @@ import android.util.Log
 import android.view.View
 import android.widget.FrameLayout
 import com.cachekid.companion.host.mission.ActiveMission
-import org.json.JSONArray
-import org.json.JSONObject
+import com.cachekid.companion.host.mission.OfflineBaseMapPackage
 import org.maplibre.android.MapLibre
 import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.camera.CameraPosition
 import org.maplibre.android.geometry.LatLng
 import org.maplibre.android.geometry.LatLngBounds
-import org.maplibre.android.geometry.LatLngQuad
 import org.maplibre.android.style.layers.LineLayer
 import org.maplibre.android.style.layers.PropertyFactory.lineCap
 import org.maplibre.android.style.layers.PropertyFactory.lineColor
@@ -33,17 +30,10 @@ import org.maplibre.android.style.layers.PropertyFactory.iconSize
 import org.maplibre.android.style.layers.PropertyFactory.lineJoin
 import org.maplibre.android.style.layers.PropertyFactory.lineOpacity
 import org.maplibre.android.style.layers.PropertyFactory.lineWidth
-import org.maplibre.android.style.layers.PropertyFactory.rasterBrightnessMax
-import org.maplibre.android.style.layers.PropertyFactory.rasterBrightnessMin
-import org.maplibre.android.style.layers.PropertyFactory.rasterContrast
-import org.maplibre.android.style.layers.PropertyFactory.rasterOpacity
-import org.maplibre.android.style.layers.PropertyFactory.rasterSaturation
 import org.maplibre.android.style.layers.Property.LINE_CAP_ROUND
 import org.maplibre.android.style.layers.Property.LINE_JOIN_ROUND
-import org.maplibre.android.style.layers.RasterLayer
 import org.maplibre.android.style.layers.SymbolLayer
 import org.maplibre.android.style.sources.GeoJsonSource
-import org.maplibre.android.style.sources.ImageSource
 import org.maplibre.android.maps.MapLibreMap
 import org.maplibre.android.maps.MapLibreMapOptions
 import org.maplibre.android.maps.MapView
@@ -52,15 +42,15 @@ import org.maplibre.geojson.Feature
 import org.maplibre.geojson.FeatureCollection
 import org.maplibre.geojson.LineString
 import org.maplibre.geojson.Point
-import java.util.Base64
+import java.io.File
 
 class KidNativeMapController(
     context: Context,
     private val mapContainer: FrameLayout,
 ) {
     private companion object {
-        const val BASEMAP_SOURCE_ID = "cachekid-basemap-source"
-        const val BASEMAP_LAYER_ID = "cachekid-basemap-layer"
+        const val OFFLINE_BASEMAP_SOURCE_ID = "cachekid-offline-basemap-source"
+        const val OFFLINE_BASEMAP_LAYER_ID = "cachekid-offline-basemap-layer"
         const val TARGET_SOURCE_ID = "cachekid-target-source"
         const val PLAYER_SOURCE_ID = "cachekid-player-source"
         const val ROUTE_SOURCE_ID = "cachekid-route-source"
@@ -96,7 +86,7 @@ class KidNativeMapController(
     private var lastOrientationCommitAtMillis: Long = 0L
     private var displayedMissionId: String? = null
     private var displayedRouteStart: LatLng? = null
-    private var displayedBaseMapKey: String? = null
+    private var displayedStyleKey: String? = null
     private var lastCameraDebugInfo: CameraDebugInfo? = null
     private var viewportTopInsetPx: Float? = null
     private var viewportBottomInsetPx: Float? = null
@@ -131,13 +121,7 @@ class KidNativeMapController(
                 isRotateGesturesEnabled = false
                 isTiltGesturesEnabled = false
             }
-            map.setStyle(Style.Builder().fromJson(buildRasterStyleJson())) {
-                ensureMissionOverlayLayers(it)
-                mapStyleLoaded = true
-                Log.d(CAMERA_LOG_TAG, "style-ready mission=${currentMission?.missionId ?: "--"}")
-                updateMissionOverlays()
-                updateCamera()
-            }
+            applyStyleForMission(map, currentMission)
         }
     }
 
@@ -170,7 +154,7 @@ class KidNativeMapController(
             lastOrientationCommitAtMillis = 0L
             displayedMissionId = null
             displayedRouteStart = null
-            displayedBaseMapKey = null
+            displayedStyleKey = null
             previousCourseLocation = null
             currentCourseBearingDegrees = null
         } else if (missionChanged || displayedMissionId != mission.missionId || displayedRouteStart == null) {
@@ -178,13 +162,16 @@ class KidNativeMapController(
             lastOrientationCommitAtMillis = 0L
             displayedMissionId = mission.missionId
             displayedRouteStart = resolveDisplayRouteStart(mission)
-            displayedBaseMapKey = null
             previousCourseLocation = null
             currentCourseBearingDegrees = null
             lastZoneFitUsedStrict = true
         }
         mapContainer.visibility = if (mission != null) View.VISIBLE else View.GONE
-        updateMissionOverlays()
+        if (missionChanged || mission == null) {
+            applyStyleForMission(mapLibreMap ?: return, mission)
+        } else {
+            updateMissionOverlays()
+        }
         if (missionChanged || mission == null) {
             updateCamera(animate = false)
         }
@@ -315,7 +302,6 @@ class KidNativeMapController(
         val map = mapLibreMap ?: return
         val mission = currentMission ?: return
         val style = map.style ?: return
-        ensureBaseMapLayer(style, mission)
 
         val targetSource = style.getSourceAs<GeoJsonSource>(TARGET_SOURCE_ID) ?: return
         val playerSource = style.getSourceAs<GeoJsonSource>(PLAYER_SOURCE_ID) ?: return
@@ -426,83 +412,46 @@ class KidNativeMapController(
         }
     }
 
-    private fun ensureBaseMapLayer(style: Style, mission: ActiveMission) {
-        val baseMap = mission.baseMap ?: mission.offlineMap ?: run {
-            if (style.getLayer(BASEMAP_LAYER_ID) != null) {
-                style.removeLayer(BASEMAP_LAYER_ID)
-            }
-            if (style.getSource(BASEMAP_SOURCE_ID) != null) {
-                style.removeSource(BASEMAP_SOURCE_ID)
-            }
-            displayedBaseMapKey = null
-            return
-        }
-        val basemapBitmap = bitmapFromMissionMap(baseMap) ?: run {
-            Log.w(CAMERA_LOG_TAG, "basemap decode failed mission=${mission.missionId} asset=${baseMap.assetPath}")
-            if (style.getLayer(BASEMAP_LAYER_ID) != null) {
-                style.removeLayer(BASEMAP_LAYER_ID)
-            }
-            if (style.getSource(BASEMAP_SOURCE_ID) != null) {
-                style.removeSource(BASEMAP_SOURCE_ID)
-            }
-            displayedBaseMapKey = null
-            return
-        }
-        val baseMapKey = listOf(
-            mission.missionId,
-            baseMap.assetPath,
-            baseMap.bounds.minLatitude,
-            baseMap.bounds.minLongitude,
-            baseMap.bounds.maxLatitude,
-            baseMap.bounds.maxLongitude,
-        ).joinToString("|")
-        if (displayedBaseMapKey == baseMapKey && style.getSource(BASEMAP_SOURCE_ID) != null) {
+    private fun applyStyleForMission(map: MapLibreMap, mission: ActiveMission?) {
+        val styleKey = buildStyleKey(mission)
+        if (styleKey == displayedStyleKey && mapStyleLoaded) {
+            updateMissionOverlays()
             return
         }
 
-        val baseMapQuad = LatLngQuad(
-            LatLng(baseMap.bounds.maxLatitude, baseMap.bounds.minLongitude),
-            LatLng(baseMap.bounds.maxLatitude, baseMap.bounds.maxLongitude),
-            LatLng(baseMap.bounds.minLatitude, baseMap.bounds.maxLongitude),
-            LatLng(baseMap.bounds.minLatitude, baseMap.bounds.minLongitude),
-        )
-        val existingSource = style.getSourceAs<ImageSource>(BASEMAP_SOURCE_ID)
-        if (existingSource == null) {
-            style.addSource(ImageSource(BASEMAP_SOURCE_ID, baseMapQuad, basemapBitmap))
-        } else {
-            existingSource.setCoordinates(baseMapQuad)
-            existingSource.setImage(basemapBitmap)
+        mapStyleLoaded = false
+        displayedStyleKey = styleKey
+        map.setStyle(Style.Builder().fromJson(buildStyleJsonForMission(mission))) {
+            ensureMissionOverlayLayers(it)
+            mapStyleLoaded = true
+            Log.d(CAMERA_LOG_TAG, "style-ready mission=${currentMission?.missionId ?: "--"} style=$styleKey")
+            updateMissionOverlays()
+            updateCamera()
         }
-        if (style.getLayer(BASEMAP_LAYER_ID) == null) {
-            style.addLayerAt(
-                RasterLayer(BASEMAP_LAYER_ID, BASEMAP_SOURCE_ID).withProperties(
-                    rasterSaturation(-1f),
-                    rasterContrast(0.08f),
-                    rasterBrightnessMin(0.28f),
-                    rasterBrightnessMax(1.02f),
-                    rasterOpacity(0.96f),
-                ),
-                2,
-            )
-        }
-        displayedBaseMapKey = baseMapKey
-        Log.d(
-            CAMERA_LOG_TAG,
-            "basemap-ready mission=${mission.missionId} asset=${baseMap.assetPath} bounds=${baseMap.bounds.minLatitude},${baseMap.bounds.minLongitude}|${baseMap.bounds.maxLatitude},${baseMap.bounds.maxLongitude}",
-        )
     }
 
-    private fun bitmapFromMissionMap(map: com.cachekid.companion.host.mission.MissionOfflineMap): Bitmap? {
-        if (map.assetPath.endsWith(".png", ignoreCase = true)) {
-            val base64Payload = Regex("""data:image/png;base64,([A-Za-z0-9+/=]+)""")
-                .find(map.svgContent)
-                ?.groupValues
-                ?.getOrNull(1)
-                ?: return null
-            val pngBytes = runCatching { Base64.getDecoder().decode(base64Payload) }.getOrNull() ?: return null
-            return BitmapFactory.decodeByteArray(pngBytes, 0, pngBytes.size)
+    private fun buildStyleKey(mission: ActiveMission?): String {
+        val offlinePackage = mission?.offlineBaseMapPackage
+        return if (offlinePackage != null) {
+            listOf(
+                "offline",
+                offlinePackage.id,
+                offlinePackage.version,
+                offlinePackage.tileAssetPath,
+                offlinePackage.styleAssetPath,
+            ).joinToString("|")
+        } else {
+            "missing-offline-map"
         }
-        return null
+    }
+
+    private fun buildStyleJsonForMission(mission: ActiveMission?): String {
+        val offlinePackage = mission?.offlineBaseMapPackage
+        return if (offlinePackage != null) {
+            buildOfflinePackageStyleJson(offlinePackage)
+        } else {
+            buildMissingOfflineMapStyleJson()
+        }
     }
 
     private fun buildTargetFeatures(targetPoint: Point): List<Feature> {
@@ -1188,62 +1137,72 @@ class KidNativeMapController(
         return result[0].toDouble()
     }
 
-    private fun buildRasterStyleJson(): String {
-        return JSONObject().apply {
-            put("version", 8)
-            put("name", "CacheKid Native Kid Map")
-            put(
-                "sources",
-                JSONObject().apply {
-                    put(
-                        "osm-raster",
-                        JSONObject().apply {
-                            put("type", "raster")
-                            put(
-                                "tiles",
-                                JSONArray().put("https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
-                            )
-                            put("tileSize", 256)
-                            put("minzoom", 0)
-                            put("maxzoom", 19)
-                        },
-                    )
+    private fun buildMissingOfflineMapStyleJson(): String {
+        return """
+            {
+              "version": 8,
+              "name": "CacheKid Missing Offline Map",
+              "sources": {},
+              "layers": [
+                {
+                  "id": "background",
+                  "type": "background",
+                  "paint": {
+                    "background-color": "#f4f2ea"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+
+    private fun buildOfflinePackageStyleJson(offlinePackage: OfflineBaseMapPackage): String {
+        val tileUrl = "pmtiles://file://${offlinePackage.packageDirectory.absolutePath}/${offlinePackage.tileAssetPath}"
+        val styleFile = File(offlinePackage.packageDirectory, offlinePackage.styleAssetPath)
+        val packageStyle = runCatching { styleFile.readText() }.getOrNull()
+        if (!packageStyle.isNullOrBlank()) {
+            return packageStyle
+                .replace("\${CACHEKID_PMTILES_URL}", tileUrl)
+                .replace("CACHEKID_PMTILES_URL", tileUrl)
+                .replace("pmtiles://cachekid-local-map", tileUrl)
+        }
+
+        return """
+            {
+              "version": 8,
+              "name": "CacheKid Offline ${escapeJson(offlinePackage.id)}",
+              "sources": {
+                "$OFFLINE_BASEMAP_SOURCE_ID": {
+                  "type": "vector",
+                  "url": "${escapeJson(tileUrl)}",
+                  "minzoom": ${offlinePackage.minZoom},
+                  "maxzoom": ${offlinePackage.maxZoom}
+                }
+              },
+              "layers": [
+                {
+                  "id": "background",
+                  "type": "background",
+                  "paint": {
+                    "background-color": "#f4f2ea"
+                  }
                 },
-            )
-            put(
-                "layers",
-                JSONArray()
-                    .put(
-                        JSONObject().apply {
-                            put("id", "background")
-                            put("type", "background")
-                            put(
-                                "paint",
-                                JSONObject().apply {
-                                    put("background-color", "#f4f2ea")
-                                },
-                            )
-                        },
-                    )
-                    .put(
-                        JSONObject().apply {
-                            put("id", "osm-raster")
-                            put("type", "raster")
-                            put("source", "osm-raster")
-                            put(
-                                "paint",
-                                JSONObject().apply {
-                                    put("raster-saturation", -1)
-                                    put("raster-contrast", 0.08)
-                                    put("raster-brightness-min", 0.28)
-                                    put("raster-brightness-max", 1.02)
-                                    put("raster-opacity", 0.93)
-                                },
-                            )
-                        },
-                    ),
-            )
-        }.toString()
+                {
+                  "id": "$OFFLINE_BASEMAP_LAYER_ID",
+                  "type": "background",
+                  "paint": {
+                    "background-color": "#e1dfd6"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+
+    private fun escapeJson(value: String): String {
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
     }
 
     private data class ActiveRouteState(

--- a/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepositoryTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepositoryTest.kt
@@ -46,6 +46,7 @@ class OfflineBaseMapPackageRepositoryTest {
         assertEquals(OfflineBaseMapPackageFormat.PMTILES_VECTOR, offlinePackage?.format)
         assertEquals("map.pmtiles", offlinePackage?.tileAssetPath)
         assertEquals("style.json", offlinePackage?.styleAssetPath)
+        assertEquals("lower-saxony", offlinePackage?.packageDirectory?.name)
         assertEquals(14, offlinePackage?.maxZoom)
     }
 

--- a/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepositoryTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageRepositoryTest.kt
@@ -1,0 +1,110 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class OfflineBaseMapPackageRepositoryTest {
+
+    @Test
+    fun `repository discovers covering pmtiles package`() {
+        val baseDirectory = createTempDirectory("cachekid-real-offline-map").toFile()
+        createOfflinePackage(
+            baseDirectory = baseDirectory,
+            directoryName = "lower-saxony",
+            metadata = """
+                {
+                  "id": "de-ni",
+                  "displayName": "Lower Saxony",
+                  "version": "2026.04",
+                  "format": "pmtiles-vector",
+                  "tileAssetPath": "map.pmtiles",
+                  "styleAssetPath": "style.json",
+                  "minZoom": 0,
+                  "maxZoom": 14,
+                  "attribution": "OpenStreetMap contributors",
+                  "bounds": {
+                    "minLatitude": 51.20,
+                    "minLongitude": 6.30,
+                    "maxLatitude": 53.90,
+                    "maxLongitude": 11.70
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val repository = OfflineBaseMapPackageRepository(baseDirectory)
+
+        val offlinePackage = repository.findCovering(MissionTarget(52.617, 10.0543))
+
+        assertNotNull(offlinePackage)
+        assertEquals("de-ni", offlinePackage?.id)
+        assertEquals("Lower Saxony", offlinePackage?.displayName)
+        assertEquals(OfflineBaseMapPackageFormat.PMTILES_VECTOR, offlinePackage?.format)
+        assertEquals("map.pmtiles", offlinePackage?.tileAssetPath)
+        assertEquals("style.json", offlinePackage?.styleAssetPath)
+        assertEquals(14, offlinePackage?.maxZoom)
+    }
+
+    @Test
+    fun `repository rejects static legacy basemap package as real offline map`() {
+        val baseDirectory = createTempDirectory("cachekid-legacy-basemap").toFile()
+        val legacyDirectory = File(baseDirectory, "celle-tile").apply { mkdirs() }
+        File(legacyDirectory, MissionPackageSchema.MAP_PNG_FILE).writeBytes(byteArrayOf(1, 2, 3))
+        File(legacyDirectory, MissionPackageSchema.MAP_METADATA_FILE).writeText(
+            """
+                {
+                  "assetPath": "map.png",
+                  "bounds": {
+                    "minLatitude": 52.60,
+                    "minLongitude": 10.04,
+                    "maxLatitude": 52.65,
+                    "maxLongitude": 10.11
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val repository = OfflineBaseMapPackageRepository(baseDirectory)
+
+        assertNull(repository.findCovering(MissionTarget(52.617, 10.0543)))
+    }
+
+    @Test
+    fun `repository does not use nearest package when target is outside coverage`() {
+        val baseDirectory = createTempDirectory("cachekid-real-offline-map-outside").toFile()
+        createOfflinePackage(
+            baseDirectory = baseDirectory,
+            directoryName = "berlin",
+            metadata = """
+                {
+                  "format": "pmtiles-vector",
+                  "bounds": {
+                    "minLatitude": 52.40,
+                    "minLongitude": 13.20,
+                    "maxLatitude": 52.70,
+                    "maxLongitude": 13.60
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        val repository = OfflineBaseMapPackageRepository(baseDirectory)
+
+        assertNull(repository.findCovering(MissionTarget(52.617, 10.0543)))
+    }
+
+    private fun createOfflinePackage(
+        baseDirectory: File,
+        directoryName: String,
+        metadata: String,
+    ) {
+        val packageDirectory = File(baseDirectory, directoryName).apply { mkdirs() }
+        File(packageDirectory, MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE).writeBytes(byteArrayOf(1, 2, 3))
+        File(packageDirectory, MissionPackageSchema.OFFLINE_MAP_STYLE_FILE).writeText("""{"version":8}""")
+        File(packageDirectory, MissionPackageSchema.OFFLINE_MAP_METADATA_FILE).writeText(metadata)
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageSideloadImporterTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageSideloadImporterTest.kt
@@ -1,0 +1,88 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+
+class OfflineBaseMapPackageSideloadImporterTest {
+
+    private val sideloadImporter = OfflineBaseMapPackageSideloadImporter()
+
+    @Test
+    fun `sideload importer installs latest offline map package and archives it`() {
+        val tempRoot = createTempDirectory("cachekid-offline-map-sideload").toFile()
+        val offlineMapBaseDirectory = File(tempRoot, "offline-maps")
+        val sideloadDirectory = File(tempRoot, "offline-map-sideload").apply { mkdirs() }
+        val zipFile = File(sideloadDirectory, "de-ni.zip")
+        zipFile.writeBytes(validPackageZip())
+
+        val result = sideloadImporter.importLatest(
+            offlineMapBaseDirectory = offlineMapBaseDirectory,
+            candidateDirectories = listOf(sideloadDirectory),
+        )
+
+        assertEquals(OfflineBaseMapPackageSideloadStatus.IMPORTED, result.status)
+        assertTrue(requireNotNull(result.installResult).isSuccess)
+        assertFalse(zipFile.exists())
+        assertTrue(File(sideloadDirectory, "imported/de-ni.zip").exists())
+        assertTrue(File(offlineMapBaseDirectory, "de-ni/map.pmtiles").exists())
+    }
+
+    @Test
+    fun `sideload importer archives invalid package as failed`() {
+        val tempRoot = createTempDirectory("cachekid-offline-map-sideload-failed").toFile()
+        val offlineMapBaseDirectory = File(tempRoot, "offline-maps")
+        val sideloadDirectory = File(tempRoot, "offline-map-sideload").apply { mkdirs() }
+        val zipFile = File(sideloadDirectory, "broken.zip")
+        zipFile.writeText("not-a-zip")
+
+        val result = sideloadImporter.importLatest(
+            offlineMapBaseDirectory = offlineMapBaseDirectory,
+            candidateDirectories = listOf(sideloadDirectory),
+        )
+
+        assertEquals(OfflineBaseMapPackageSideloadStatus.IMPORT_FAILED, result.status)
+        assertTrue(result.errors.isNotEmpty())
+        assertFalse(zipFile.exists())
+        assertTrue(File(sideloadDirectory, "failed/broken.zip").exists())
+        assertTrue(File(sideloadDirectory, "failed/broken.zip.error.txt").exists())
+    }
+
+    private fun validPackageZip(): ByteArray {
+        return zipOf(
+            MissionPackageSchema.OFFLINE_MAP_METADATA_FILE to """
+                {
+                  "id": "de-ni",
+                  "displayName": "Lower Saxony",
+                  "format": "pmtiles-vector",
+                  "bounds": {
+                    "minLatitude": 51.20,
+                    "minLongitude": 6.30,
+                    "maxLatitude": 53.90,
+                    "maxLongitude": 11.70
+                  }
+                }
+            """.trimIndent().toByteArray(),
+            MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE to byteArrayOf(1, 2, 3),
+            MissionPackageSchema.OFFLINE_MAP_STYLE_FILE to """{"version":8}""".toByteArray(),
+        )
+    }
+
+    private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zipOutput ->
+            entries.forEach { (path, bytes) ->
+                zipOutput.putNextEntry(ZipEntry(path))
+                zipOutput.write(bytes)
+                zipOutput.closeEntry()
+            }
+        }
+        return output.toByteArray()
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstallerTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/OfflineBaseMapPackageZipInstallerTest.kt
@@ -1,0 +1,93 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+
+class OfflineBaseMapPackageZipInstallerTest {
+
+    private val installer = OfflineBaseMapPackageZipInstaller()
+
+    @Test
+    fun `installer stores valid pmtiles package`() {
+        val baseDirectory = createTempDirectory("cachekid-offline-map-install").toFile()
+
+        val result = installer.install(baseDirectory, validPackageZip())
+
+        assertTrue(result.isSuccess)
+        assertEquals("de-ni", result.offlinePackage?.id)
+        assertTrue(File(baseDirectory, "de-ni/offline-map.json").exists())
+        assertTrue(File(baseDirectory, "de-ni/map.pmtiles").exists())
+        assertTrue(File(baseDirectory, "de-ni/style.json").exists())
+    }
+
+    @Test
+    fun `installer rejects package with missing pmtiles archive`() {
+        val baseDirectory = createTempDirectory("cachekid-offline-map-missing").toFile()
+        val result = installer.install(
+            baseDirectory,
+            zipOf(
+                MissionPackageSchema.OFFLINE_MAP_METADATA_FILE to validMetadata().toByteArray(),
+                MissionPackageSchema.OFFLINE_MAP_STYLE_FILE to """{"version":8}""".toByteArray(),
+            ),
+        )
+
+        assertFalse(result.isSuccess)
+        assertTrue(result.errors.joinToString(" ").contains("map.pmtiles"))
+    }
+
+    @Test
+    fun `installer rejects unsafe zip entry paths`() {
+        val baseDirectory = createTempDirectory("cachekid-offline-map-unsafe").toFile()
+        val result = installer.install(
+            baseDirectory,
+            zipOf("../offline-map.json" to validMetadata().toByteArray()),
+        )
+
+        assertFalse(result.isSuccess)
+        assertEquals(listOf("Offline map ZIP could not be decoded."), result.errors)
+    }
+
+    private fun validPackageZip(): ByteArray {
+        return zipOf(
+            MissionPackageSchema.OFFLINE_MAP_METADATA_FILE to validMetadata().toByteArray(),
+            MissionPackageSchema.OFFLINE_MAP_PMTILES_FILE to byteArrayOf(1, 2, 3),
+            MissionPackageSchema.OFFLINE_MAP_STYLE_FILE to """{"version":8}""".toByteArray(),
+        )
+    }
+
+    private fun validMetadata(): String {
+        return """
+            {
+              "id": "de-ni",
+              "displayName": "Lower Saxony",
+              "version": "2026.04",
+              "format": "pmtiles-vector",
+              "bounds": {
+                "minLatitude": 51.20,
+                "minLongitude": 6.30,
+                "maxLatitude": 53.90,
+                "maxLongitude": 11.70
+              }
+            }
+        """.trimIndent()
+    }
+
+    private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray {
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zipOutput ->
+            entries.forEach { (path, bytes) ->
+                zipOutput.putNextEntry(ZipEntry(path))
+                zipOutput.write(bytes)
+                zipOutput.closeEntry()
+            }
+        }
+        return output.toByteArray()
+    }
+}

--- a/docs/engineering-model.md
+++ b/docs/engineering-model.md
@@ -251,6 +251,14 @@ The intended offline map architecture is:
 
 Mission-specific generated map assets may exist as prototype code paths, but they should not become hidden architectural defaults.
 
+The current target package format is a device-local PMTiles package:
+
+- `offline-map.json` manifest
+- `map.pmtiles` tile archive
+- `style.json` local MapLibre style
+
+Legacy `map.png` / `map.svg` basemap assets are prototype fallbacks only. They must remain distinct from real offline map packages so the app can show an explicit missing-map state instead of implying that a full offline map is available.
+
 ## 16. Kid device input rule
 
 The kid runtime must support both:

--- a/docs/offline-map-architecture.md
+++ b/docs/offline-map-architecture.md
@@ -53,6 +53,18 @@ The initial supported format is `pmtiles-vector`. This matches the current MapLi
 - A mission target outside all installed package bounds is a missing-map state. The runtime must not silently choose the nearest unrelated map package.
 - Online OSM raster tiles are a development fallback only and should not be the production kid-map default.
 
+## Installation Path
+
+The on-device storage root is the app-private offline map directory:
+
+```text
+files/offline-basemaps/<package-id>/
+```
+
+The development sideload path accepts zip files containing `offline-map.json`, `map.pmtiles`, and `style.json`.
+The installer validates the manifest and required files before replacing an existing package directory.
+Imported source zips are archived into `imported/`; failed imports are archived into `failed/` with an error report.
+
 ## Follow-Up Work
 
 - #26 installs and validates offline map packages on-device.

--- a/docs/offline-map-architecture.md
+++ b/docs/offline-map-architecture.md
@@ -70,6 +70,26 @@ The development sideload path accepts zip files containing `offline-map.json`, `
 The installer validates the manifest and required files before replacing an existing package directory.
 Imported source zips are archived into `imported/`; failed imports are archived into `failed/` with an error report.
 
+## Development Package Builder
+
+Small real-map test packages can be generated from OpenStreetMap/Overpass data with:
+
+```bash
+pip install pmtiles==3.7.0 mapbox-vector-tile==2.1.0
+python3 tools/build_offline_map_package.py \
+  --package-id test-celle \
+  --display-name "Test Celle" \
+  --version dev \
+  --min-lat 52.58 \
+  --min-lon 10.00 \
+  --max-lat 52.65 \
+  --max-lon 10.09 \
+  --output /tmp/cachekid-test-celle.zip
+```
+
+The builder creates an installable sideload zip with a real PMTiles vector archive and a label-free MapLibre style.
+It is intended for small device-validation regions. It is not the final country-scale update pipeline.
+
 ## Follow-Up Work
 
 - #26 installs and validates offline map packages on-device.

--- a/docs/offline-map-architecture.md
+++ b/docs/offline-map-architecture.md
@@ -1,0 +1,60 @@
+# Offline Map Architecture
+
+CacheKid needs a real kid-device offline map, not mission-specific static background images.
+
+## Target
+
+The Meebook stores one or more installable offline map packages. A mission package carries route, waypoint, player, and target data only. At runtime the kid map composes:
+
+- a device-local offline basemap package
+- mission route and waypoint overlays
+- the fixed treasure `X`
+- the current player `O`
+
+## Package Format
+
+The target package format is a directory under the device offline-map root:
+
+```text
+offline-maps/<package-id>/
+  offline-map.json
+  map.pmtiles
+  style.json
+```
+
+`offline-map.json` is the package manifest:
+
+```json
+{
+  "id": "de-ni",
+  "displayName": "Lower Saxony",
+  "version": "2026.04",
+  "format": "pmtiles-vector",
+  "tileAssetPath": "map.pmtiles",
+  "styleAssetPath": "style.json",
+  "minZoom": 0,
+  "maxZoom": 14,
+  "attribution": "OpenStreetMap contributors",
+  "bounds": {
+    "minLatitude": 51.20,
+    "minLongitude": 6.30,
+    "maxLatitude": 53.90,
+    "maxLongitude": 11.70
+  }
+}
+```
+
+The initial supported format is `pmtiles-vector`. This matches the current MapLibre Android dependency line, which supports PMTiles URL protocols in recent 11.x releases. The package must include a local `style.json` that references the local PMTiles archive and keeps the kid presentation label-light or label-free.
+
+## Runtime Rules
+
+- The kid app must only treat packages with `offline-map.json`, `map.pmtiles`, and `style.json` as real offline maps.
+- Legacy `map.png` / `map.svg` basemaps are prototype fallback assets, not proof that offline maps are installed.
+- A mission target outside all installed package bounds is a missing-map state. The runtime must not silently choose the nearest unrelated map package.
+- Online OSM raster tiles are a development fallback only and should not be the production kid-map default.
+
+## Follow-Up Work
+
+- #26 installs and validates offline map packages on-device.
+- #25 wires the kid renderer to local PMTiles styles and removes the online raster default from the production path.
+- #27 tracks source selection and tile-generation/licensing decisions for the chosen PMTiles basemap.

--- a/docs/offline-map-architecture.md
+++ b/docs/offline-map-architecture.md
@@ -45,6 +45,11 @@ offline-maps/<package-id>/
 ```
 
 The initial supported format is `pmtiles-vector`. This matches the current MapLibre Android dependency line, which supports PMTiles URL protocols in recent 11.x releases. The package must include a local `style.json` that references the local PMTiles archive and keeps the kid presentation label-light or label-free.
+The app replaces one of these placeholders in `style.json` with the installed local PMTiles URL:
+
+- `${CACHEKID_PMTILES_URL}`
+- `CACHEKID_PMTILES_URL`
+- `pmtiles://cachekid-local-map`
 
 ## Runtime Rules
 

--- a/tools/build_offline_map_package.py
+++ b/tools/build_offline_map_package.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Build a small installable CacheKid offline map package.
+
+The generated package is intentionally region-sized, not country-sized. It is
+used to validate the real PMTiles renderer path on a kid device before we lock
+down the larger map production/update workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import math
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+try:
+    import mapbox_vector_tile
+    from pmtiles.tile import Compression, TileType, zxy_to_tileid
+    from pmtiles.writer import write as write_pmtiles
+    from shapely.geometry import LineString, MultiPolygon, Polygon, box, mapping
+except ImportError as exc:  # pragma: no cover - exercised by users without deps.
+    raise SystemExit(
+        "Missing Python dependencies. Install with:\n"
+        "  pip install pmtiles==3.7.0 mapbox-vector-tile==2.1.0\n"
+    ) from exc
+
+
+@dataclass(frozen=True)
+class Bounds:
+    min_latitude: float
+    min_longitude: float
+    max_latitude: float
+    max_longitude: float
+
+    def padded(self, padding_ratio: float) -> "Bounds":
+        lat_padding = (self.max_latitude - self.min_latitude) * padding_ratio
+        lon_padding = (self.max_longitude - self.min_longitude) * padding_ratio
+        return Bounds(
+            min_latitude=max(self.min_latitude - lat_padding, -85.0),
+            min_longitude=max(self.min_longitude - lon_padding, -180.0),
+            max_latitude=min(self.max_latitude + lat_padding, 85.0),
+            max_longitude=min(self.max_longitude + lon_padding, 180.0),
+        )
+
+
+@dataclass(frozen=True)
+class RenderFeature:
+    layer: str
+    geometry: Any
+    properties: dict[str, Any]
+
+
+def main() -> None:
+    args = parse_args()
+    bounds = Bounds(
+        min_latitude=args.min_lat,
+        min_longitude=args.min_lon,
+        max_latitude=args.max_lat,
+        max_longitude=args.max_lon,
+    ).padded(args.padding)
+
+    if args.overpass_json:
+        map_data = json.loads(Path(args.overpass_json).read_text(encoding="utf-8"))
+    else:
+        map_data = fetch_overpass(bounds, args.overpass_endpoint)
+
+    features = extract_features(map_data)
+    if not features:
+        raise SystemExit("Overpass data did not contain renderable map features.")
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    build_package(
+        package_id=args.package_id,
+        display_name=args.display_name,
+        version=args.version,
+        bounds=bounds,
+        min_zoom=args.min_zoom,
+        max_zoom=args.max_zoom,
+        features=features,
+        output_zip=output,
+    )
+    print(f"Wrote {output}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-id", required=True)
+    parser.add_argument("--display-name", required=True)
+    parser.add_argument("--version", default="dev")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--min-lat", type=float, required=True)
+    parser.add_argument("--min-lon", type=float, required=True)
+    parser.add_argument("--max-lat", type=float, required=True)
+    parser.add_argument("--max-lon", type=float, required=True)
+    parser.add_argument("--padding", type=float, default=0.15)
+    parser.add_argument("--min-zoom", type=int, default=12)
+    parser.add_argument("--max-zoom", type=int, default=15)
+    parser.add_argument("--overpass-json")
+    parser.add_argument(
+        "--overpass-endpoint",
+        default="https://overpass-api.de/api/interpreter",
+    )
+    return parser.parse_args()
+
+
+def fetch_overpass(bounds: Bounds, endpoint: str) -> dict[str, Any]:
+    query = f"""
+        [out:json][timeout:35];
+        (
+          way["highway"]({bounds.min_latitude},{bounds.min_longitude},{bounds.max_latitude},{bounds.max_longitude});
+          way["waterway"]({bounds.min_latitude},{bounds.min_longitude},{bounds.max_latitude},{bounds.max_longitude});
+          way["natural"="water"]({bounds.min_latitude},{bounds.min_longitude},{bounds.max_latitude},{bounds.max_longitude});
+          way["landuse"="forest"]({bounds.min_latitude},{bounds.min_longitude},{bounds.max_latitude},{bounds.max_longitude});
+          way["natural"="wood"]({bounds.min_latitude},{bounds.min_longitude},{bounds.max_latitude},{bounds.max_longitude});
+        );
+        out tags geom;
+    """
+    payload = urllib.parse.urlencode({"data": query}).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            "User-Agent": "CacheKidCompanionOfflineMapBuilder/1.0",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=45) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def extract_features(map_data: dict[str, Any]) -> list[RenderFeature]:
+    features: list[RenderFeature] = []
+    for element in map_data.get("elements", []):
+        geometry = element.get("geometry") or []
+        points = [
+            (point["lon"], point["lat"])
+            for point in geometry
+            if "lat" in point and "lon" in point
+        ]
+        if len(points) < 2:
+            continue
+
+        tags = element.get("tags") or {}
+        layer = classify_layer(tags)
+        if layer is None:
+            continue
+
+        if layer in {"water", "land"} and len(points) >= 4 and points[0] == points[-1]:
+            shape = Polygon(points)
+            if not shape.is_valid:
+                shape = shape.buffer(0)
+            if shape.is_empty:
+                continue
+        else:
+            shape = LineString(points)
+            if shape.is_empty or shape.length <= 0:
+                continue
+
+        features.append(
+            RenderFeature(
+                layer=layer,
+                geometry=shape,
+                properties={
+                    "class": classify_class(tags),
+                    "name": tags.get("name", ""),
+                },
+            )
+        )
+    return features
+
+
+def classify_layer(tags: dict[str, Any]) -> str | None:
+    if tags.get("natural") == "water" or tags.get("waterway"):
+        return "water"
+    if tags.get("landuse") == "forest" or tags.get("natural") == "wood":
+        return "land"
+    if tags.get("highway"):
+        return "roads"
+    return None
+
+
+def classify_class(tags: dict[str, Any]) -> str:
+    highway = tags.get("highway", "")
+    if highway in {"motorway", "trunk", "primary", "secondary", "tertiary"}:
+        return "major"
+    if highway:
+        return "minor"
+    if tags.get("waterway"):
+        return "waterway"
+    if tags.get("natural") == "water":
+        return "water"
+    if tags.get("landuse") == "forest" or tags.get("natural") == "wood":
+        return "forest"
+    return "other"
+
+
+def build_package(
+    package_id: str,
+    display_name: str,
+    version: str,
+    bounds: Bounds,
+    min_zoom: int,
+    max_zoom: int,
+    features: list[RenderFeature],
+    output_zip: Path,
+) -> None:
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        pmtiles_path = temp_dir / "map.pmtiles"
+        write_vector_pmtiles(
+            output_path=pmtiles_path,
+            bounds=bounds,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            features=features,
+        )
+        (temp_dir / "offline-map.json").write_text(
+            json.dumps(
+                build_manifest(package_id, display_name, version, bounds, min_zoom, max_zoom),
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (temp_dir / "style.json").write_text(build_style_json(min_zoom, max_zoom), encoding="utf-8")
+
+        with zipfile.ZipFile(output_zip, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for name in ("offline-map.json", "map.pmtiles", "style.json"):
+                archive.write(temp_dir / name, arcname=name)
+
+
+def write_vector_pmtiles(
+    output_path: Path,
+    bounds: Bounds,
+    min_zoom: int,
+    max_zoom: int,
+    features: list[RenderFeature],
+) -> None:
+    with write_pmtiles(str(output_path)) as writer:
+        for zoom in range(min_zoom, max_zoom + 1):
+            min_x, max_y = lonlat_to_tile(bounds.min_longitude, bounds.min_latitude, zoom)
+            max_x, min_y = lonlat_to_tile(bounds.max_longitude, bounds.max_latitude, zoom)
+            for tile_x in range(min_x, max_x + 1):
+                for tile_y in range(min_y, max_y + 1):
+                    tile = encode_tile(features, zoom, tile_x, tile_y)
+                    if tile:
+                        writer.write_tile(zxy_to_tileid(zoom, tile_x, tile_y), gzip.compress(tile))
+
+        writer.finalize(
+            {
+                "tile_compression": Compression.GZIP,
+                "tile_type": TileType.MVT,
+                "min_lon_e7": round(bounds.min_longitude * 10_000_000),
+                "min_lat_e7": round(bounds.min_latitude * 10_000_000),
+                "max_lon_e7": round(bounds.max_longitude * 10_000_000),
+                "max_lat_e7": round(bounds.max_latitude * 10_000_000),
+                "center_lon_e7": round(((bounds.min_longitude + bounds.max_longitude) / 2) * 10_000_000),
+                "center_lat_e7": round(((bounds.min_latitude + bounds.max_latitude) / 2) * 10_000_000),
+                "center_zoom": min(max_zoom, max(min_zoom, 14)),
+            },
+            {
+                "name": "CacheKid offline map",
+                "format": "pbf",
+                "bounds": [
+                    bounds.min_longitude,
+                    bounds.min_latitude,
+                    bounds.max_longitude,
+                    bounds.max_latitude,
+                ],
+                "vector_layers": [
+                    {"id": "land", "description": "Forest and wooded areas", "fields": {"class": "String"}},
+                    {"id": "water", "description": "Water bodies and waterways", "fields": {"class": "String"}},
+                    {"id": "roads", "description": "Road and path network", "fields": {"class": "String"}},
+                ],
+            },
+        )
+
+
+def encode_tile(features: list[RenderFeature], zoom: int, tile_x: int, tile_y: int) -> bytes:
+    west, south, east, north = tile_bounds(tile_x, tile_y, zoom)
+    tile_box = box(west, south, east, north)
+    layers: list[dict[str, Any]] = []
+
+    for layer_name in ("land", "water", "roads"):
+        layer_features = []
+        for feature in features:
+            if feature.layer != layer_name or not feature.geometry.intersects(tile_box):
+                continue
+            clipped = feature.geometry.intersection(tile_box)
+            if clipped.is_empty:
+                continue
+            for geometry in explode_geometry(clipped):
+                layer_features.append(
+                    {
+                        "geometry": mapping(geometry),
+                        "properties": feature.properties,
+                    }
+                )
+        if layer_features:
+            layers.append({"name": layer_name, "features": layer_features})
+
+    if not layers:
+        return b""
+
+    return mapbox_vector_tile.encode(
+        layers,
+        default_options={
+            "quantize_bounds": (west, south, east, north),
+            "extents": 4096,
+        },
+    )
+
+
+def explode_geometry(geometry: Any) -> list[Any]:
+    if geometry.geom_type in {"GeometryCollection", "MultiLineString", "MultiPolygon"}:
+        result = []
+        for item in geometry.geoms:
+            result.extend(explode_geometry(item))
+        return result
+    if isinstance(geometry, MultiPolygon):
+        return list(geometry.geoms)
+    return [geometry]
+
+
+def build_manifest(
+    package_id: str,
+    display_name: str,
+    version: str,
+    bounds: Bounds,
+    min_zoom: int,
+    max_zoom: int,
+) -> dict[str, Any]:
+    return {
+        "id": package_id,
+        "displayName": display_name,
+        "version": version,
+        "format": "pmtiles-vector",
+        "tileAssetPath": "map.pmtiles",
+        "styleAssetPath": "style.json",
+        "minZoom": min_zoom,
+        "maxZoom": max_zoom,
+        "attribution": "OpenStreetMap contributors",
+        "bounds": {
+            "minLatitude": bounds.min_latitude,
+            "minLongitude": bounds.min_longitude,
+            "maxLatitude": bounds.max_latitude,
+            "maxLongitude": bounds.max_longitude,
+        },
+    }
+
+
+def build_style_json(min_zoom: int, max_zoom: int) -> str:
+    return json.dumps(
+        {
+            "version": 8,
+            "name": "CacheKid Local Offline Map",
+            "sources": {
+                "cachekid-offline-basemap-source": {
+                    "type": "vector",
+                    "url": "pmtiles://cachekid-local-map",
+                    "minzoom": min_zoom,
+                    "maxzoom": max_zoom,
+                    "attribution": "OpenStreetMap contributors",
+                }
+            },
+            "layers": [
+                {
+                    "id": "background",
+                    "type": "background",
+                    "paint": {"background-color": "#f4f2ea"},
+                },
+                {
+                    "id": "land-forest",
+                    "type": "fill",
+                    "source": "cachekid-offline-basemap-source",
+                    "source-layer": "land",
+                    "paint": {"fill-color": "#d8ddcb", "fill-opacity": 0.78},
+                },
+                {
+                    "id": "water-fill",
+                    "type": "fill",
+                    "source": "cachekid-offline-basemap-source",
+                    "source-layer": "water",
+                    "paint": {"fill-color": "#d4dde0", "fill-opacity": 0.86},
+                },
+                {
+                    "id": "water-line",
+                    "type": "line",
+                    "source": "cachekid-offline-basemap-source",
+                    "source-layer": "water",
+                    "paint": {"line-color": "#c5d0d4", "line-width": 1.5},
+                },
+                {
+                    "id": "road-minor",
+                    "type": "line",
+                    "source": "cachekid-offline-basemap-source",
+                    "source-layer": "roads",
+                    "filter": ["==", ["get", "class"], "minor"],
+                    "paint": {"line-color": "#ffffff", "line-width": 1.1, "line-opacity": 0.9},
+                },
+                {
+                    "id": "road-major",
+                    "type": "line",
+                    "source": "cachekid-offline-basemap-source",
+                    "source-layer": "roads",
+                    "filter": ["==", ["get", "class"], "major"],
+                    "paint": {"line-color": "#f2f0e8", "line-width": 2.0, "line-opacity": 0.95},
+                },
+            ],
+        },
+        indent=2,
+    ) + "\n"
+
+
+def lonlat_to_tile(longitude: float, latitude: float, zoom: int) -> tuple[int, int]:
+    latitude = min(max(latitude, -85.05112878), 85.05112878)
+    scale = 1 << zoom
+    x = int((longitude + 180.0) / 360.0 * scale)
+    lat_rad = math.radians(latitude)
+    y = int((1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * scale)
+    return (
+        min(max(x, 0), scale - 1),
+        min(max(y, 0), scale - 1),
+    )
+
+
+def tile_bounds(tile_x: int, tile_y: int, zoom: int) -> tuple[float, float, float, float]:
+    scale = 1 << zoom
+    west = tile_x / scale * 360.0 - 180.0
+    east = (tile_x + 1) / scale * 360.0 - 180.0
+    north = math.degrees(math.atan(math.sinh(math.pi * (1.0 - 2.0 * tile_y / scale))))
+    south = math.degrees(math.atan(math.sinh(math.pi * (1.0 - 2.0 * (tile_y + 1) / scale))))
+    return west, south, east, north
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_build_offline_map_package.py
+++ b/tools/test_build_offline_map_package.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Regression tests for the offline map package builder."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+import build_offline_map_package as builder
+
+
+class OfflineMapPackageBuilderTest(unittest.TestCase):
+    def test_builds_installable_pmtiles_package(self) -> None:
+        overpass_data = {
+            "elements": [
+                {
+                    "type": "way",
+                    "id": 1,
+                    "tags": {"highway": "residential"},
+                    "geometry": [
+                        {"lat": 52.6169, "lon": 10.0540},
+                        {"lat": 52.6172, "lon": 10.0550},
+                    ],
+                },
+                {
+                    "type": "way",
+                    "id": 2,
+                    "tags": {"landuse": "forest"},
+                    "geometry": [
+                        {"lat": 52.6160, "lon": 10.0530},
+                        {"lat": 52.6160, "lon": 10.0560},
+                        {"lat": 52.6180, "lon": 10.0560},
+                        {"lat": 52.6180, "lon": 10.0530},
+                        {"lat": 52.6160, "lon": 10.0530},
+                    ],
+                },
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            output = Path(temp_dir_name) / "cachekid-test-map.zip"
+            features = builder.extract_features(overpass_data)
+
+            builder.build_package(
+                package_id="test-celle",
+                display_name="Test Celle",
+                version="test",
+                bounds=builder.Bounds(
+                    min_latitude=52.615,
+                    min_longitude=10.052,
+                    max_latitude=52.619,
+                    max_longitude=10.057,
+                ),
+                min_zoom=14,
+                max_zoom=14,
+                features=features,
+                output_zip=output,
+            )
+
+            self.assertTrue(output.exists())
+            with zipfile.ZipFile(output) as archive:
+                names = set(archive.namelist())
+                self.assertEqual({"offline-map.json", "map.pmtiles", "style.json"}, names)
+                manifest = json.loads(archive.read("offline-map.json").decode("utf-8"))
+                style = json.loads(archive.read("style.json").decode("utf-8"))
+                pmtiles = archive.read("map.pmtiles")
+
+            self.assertEqual("test-celle", manifest["id"])
+            self.assertEqual("pmtiles-vector", manifest["format"])
+            self.assertEqual("pmtiles://cachekid-local-map", style["sources"]["cachekid-offline-basemap-source"]["url"])
+            self.assertTrue(pmtiles.startswith(b"PMTiles\x03"))
+            self.assertGreater(len(pmtiles), 127)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- defines the real offline kid-map target as installable PMTiles packages: offline-map.json, map.pmtiles, style.json
- adds package discovery that treats only real PMTiles packages as offline maps and rejects legacy static PNG/SVG basemaps
- adds strict offline-map ZIP sideload/install support into files/offline-basemaps/<id>
- wires the kid renderer to installed offline-map package styles and removes the active online OSM raster/default legacy image path
- documents that current static basemap assets are prototype fallbacks, not product-complete offline maps

## Behavior / Architecture
- mission targets outside installed offline-map package bounds now have an explicit missing-map outcome at the package-discovery/rendering layer
- no nearest-map fallback is used for real offline map packages
- zip install rejects missing required files and unsafe traversal paths
- startup/resume checks offline-map-sideload for developer-pushed map packages
- package style.json can reference CACHEKID_PMTILES_URL or pmtiles://cachekid-local-map for local URL replacement

## Tests
- added OfflineBaseMapPackageRepositoryTest
- added OfflineBaseMapPackageZipInstallerTest
- added OfflineBaseMapPackageSideloadImporterTest
- ./gradlew testDebugUnitTest not run locally: no Java Runtime is installed on this machine

Closes part of #33
Addresses #27
Addresses #26
Addresses #25