### PR TITLE
Harden mission transfer sender

### DIFF
--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverEndpoint.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverEndpoint.kt
@@ -1,0 +1,79 @@
+package com.cachekid.companion.host.mission
+
+import java.net.URI
+import java.net.URISyntaxException
+import java.net.URL
+
+data class MissionPackageReceiverEndpoint(
+    val host: String,
+    val port: Int,
+) {
+    fun toUrl(): URL = URI("http", null, host, port, "/missions", null, null).toURL()
+}
+
+class MissionPackageReceiverEndpointParser {
+
+    fun parse(hostInput: String, port: Int): MissionPackageReceiverEndpointParseResult {
+        val input = hostInput.trim()
+        if (input.isBlank()) {
+            return MissionPackageReceiverEndpointParseResult(
+                endpoint = null,
+                status = MissionPackageSendStatus.MISSING_ADDRESS,
+                message = "Empfangsadresse fehlt.",
+            )
+        }
+        if (port !in 1..65535) {
+            return MissionPackageReceiverEndpointParseResult(
+                endpoint = null,
+                status = MissionPackageSendStatus.INVALID_PORT,
+                message = "Port ist ungueltig.",
+            )
+        }
+
+        val host = runCatching { extractHost(input) }.getOrNull()
+        if (host.isNullOrBlank()) {
+            return MissionPackageReceiverEndpointParseResult(
+                endpoint = null,
+                status = MissionPackageSendStatus.INVALID_ADDRESS,
+                message = "Empfangsadresse ist ungueltig.",
+            )
+        }
+
+        return MissionPackageReceiverEndpointParseResult(
+            endpoint = MissionPackageReceiverEndpoint(host = host, port = port),
+            status = MissionPackageSendStatus.SENT,
+            message = "Empfangsadresse erkannt.",
+        )
+    }
+
+    private fun extractHost(input: String): String? {
+        val hasScheme = input.contains("://")
+        val uriInput = if (hasScheme) input else "http://$input"
+        val uri = try {
+            URI(uriInput)
+        } catch (_: URISyntaxException) {
+            return null
+        }
+
+        val host = uri.host ?: return if (hasScheme) null else parseHostWithoutScheme(input)
+        return host.takeIf { it.isNotBlank() }
+    }
+
+    private fun parseHostWithoutScheme(input: String): String? {
+        val trimmed = input.trim()
+            .removePrefix("[")
+            .substringBefore("/")
+            .substringBefore(":")
+            .removeSuffix("]")
+            .trim()
+        return trimmed.takeIf { host ->
+            host.isNotBlank() && host.all { it.isLetterOrDigit() || it == '.' || it == '-' }
+        }
+    }
+}
+
+data class MissionPackageReceiverEndpointParseResult(
+    val endpoint: MissionPackageReceiverEndpoint?,
+    val status: MissionPackageSendStatus,
+    val message: String,
+)

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
@@ -4,4 +4,20 @@ data class MissionPackageSendResult(
     val isSuccess: Boolean,
     val statusCode: Int?,
     val message: String,
+    val status: MissionPackageSendStatus = if (isSuccess) {
+        MissionPackageSendStatus.SENT
+    } else {
+        MissionPackageSendStatus.FAILED
+    },
 )
+
+enum class MissionPackageSendStatus {
+    SENT,
+    MISSING_ADDRESS,
+    INVALID_ADDRESS,
+    INVALID_PORT,
+    CONNECTION_FAILED,
+    TIMEOUT,
+    HTTP_ERROR,
+    FAILED,
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
@@ -2,11 +2,14 @@ package com.cachekid.companion.host.mission
 
 import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.MalformedURLException
+import java.net.NoRouteToHostException
 import java.net.SocketTimeoutException
-import java.net.URL
+import java.net.UnknownHostException
 
 class MissionPackageSenderClient(
     private val zipCodec: MissionPackageZipCodec = MissionPackageZipCodec(),
+    private val endpointParser: MissionPackageReceiverEndpointParser = MissionPackageReceiverEndpointParser(),
 ) {
 
     fun send(
@@ -14,24 +17,26 @@ class MissionPackageSenderClient(
         port: Int,
         missionPackage: MissionPackage,
     ): MissionPackageSendResult {
-        val normalizedHost = host.trim()
-        if (normalizedHost.isBlank()) {
-            return MissionPackageSendResult(
-                isSuccess = false,
-                statusCode = null,
-                message = "Empfangsadresse fehlt.",
-            )
-        }
-        if (port !in 1..65535) {
-            return MissionPackageSendResult(
-                isSuccess = false,
-                statusCode = null,
-                message = "Port ist ungueltig.",
-            )
-        }
+        val endpointResult = endpointParser.parse(host, port)
+        val endpoint = endpointResult.endpoint ?: return MissionPackageSendResult(
+            isSuccess = false,
+            statusCode = null,
+            message = endpointResult.message,
+            status = endpointResult.status,
+        )
 
         val payload = zipCodec.encode(missionPackage)
-        val connection = (URL("http://$normalizedHost:$port/missions").openConnection() as HttpURLConnection).apply {
+        val connection = try {
+            endpoint.toUrl().openConnection() as HttpURLConnection
+        } catch (_: MalformedURLException) {
+            return MissionPackageSendResult(
+                isSuccess = false,
+                statusCode = null,
+                message = "Empfangsadresse ist ungueltig.",
+                status = MissionPackageSendStatus.INVALID_ADDRESS,
+            )
+        }
+        connection.apply {
             requestMethod = "POST"
             connectTimeout = 5000
             readTimeout = 5000
@@ -56,15 +61,31 @@ class MissionPackageSenderClient(
                 message = responseText.ifBlank {
                     if (statusCode in 200..299) "Mission gesendet." else "Transfer fehlgeschlagen."
                 },
+                status = if (statusCode in 200..299) {
+                    MissionPackageSendStatus.SENT
+                } else {
+                    MissionPackageSendStatus.HTTP_ERROR
+                },
             )
         }.getOrElse { error ->
             MissionPackageSendResult(
                 isSuccess = false,
                 statusCode = null,
                 message = when (error) {
-                    is ConnectException -> "Verbindung zum Empfaenger fehlgeschlagen. Laeuft der Empfangsmodus?"
+                    is ConnectException,
+                    is NoRouteToHostException,
+                    is UnknownHostException,
+                    -> "Verbindung zum Empfaenger fehlgeschlagen. Laeuft der Empfangsmodus?"
                     is SocketTimeoutException -> "Empfaenger antwortet nicht rechtzeitig."
                     else -> error.message ?: "Transfer fehlgeschlagen."
+                },
+                status = when (error) {
+                    is ConnectException,
+                    is NoRouteToHostException,
+                    is UnknownHostException,
+                    -> MissionPackageSendStatus.CONNECTION_FAILED
+                    is SocketTimeoutException -> MissionPackageSendStatus.TIMEOUT
+                    else -> MissionPackageSendStatus.FAILED
                 },
             )
         }.also {

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverEndpointParserTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverEndpointParserTest.kt
@@ -1,0 +1,88 @@
+package com.cachekid.companion.host.mission
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MissionPackageReceiverEndpointParserTest {
+
+    private val parser = MissionPackageReceiverEndpointParser()
+
+    @Test
+    fun `parser accepts plain host`() {
+        val result = parser.parse("192.168.0.23", 8765)
+
+        assertEquals(MissionPackageSendStatus.SENT, result.status)
+        assertEquals("192.168.0.23", result.endpoint?.host)
+        assertEquals(8765, result.endpoint?.port)
+        assertEquals("http://192.168.0.23:8765/missions", result.endpoint?.toUrl().toString())
+    }
+
+    @Test
+    fun `parser accepts pasted http url and keeps configured port`() {
+        val result = parser.parse("http://192.168.0.23:9999/missions", 8765)
+
+        assertEquals(MissionPackageSendStatus.SENT, result.status)
+        assertEquals("192.168.0.23", result.endpoint?.host)
+        assertEquals(8765, result.endpoint?.port)
+    }
+
+    @Test
+    fun `parser accepts host with trailing path`() {
+        val result = parser.parse("192.168.0.23/status", 8765)
+
+        assertEquals(MissionPackageSendStatus.SENT, result.status)
+        assertEquals("192.168.0.23", result.endpoint?.host)
+    }
+
+    @Test
+    fun `parser accepts host with pasted port and keeps configured port`() {
+        val result = parser.parse("kid-reader.local:9999/status", 8765)
+
+        assertEquals(MissionPackageSendStatus.SENT, result.status)
+        assertEquals("kid-reader.local", result.endpoint?.host)
+        assertEquals(8765, result.endpoint?.port)
+    }
+
+    @Test
+    fun `parser rejects blank address`() {
+        val result = parser.parse("  ", 8765)
+
+        assertEquals(MissionPackageSendStatus.MISSING_ADDRESS, result.status)
+        assertNull(result.endpoint)
+    }
+
+    @Test
+    fun `parser rejects invalid port`() {
+        val result = parser.parse("192.168.0.23", -1)
+
+        assertEquals(MissionPackageSendStatus.INVALID_PORT, result.status)
+        assertNull(result.endpoint)
+    }
+
+    @Test
+    fun `parser rejects malformed address`() {
+        val result = parser.parse("not a host", 8765)
+
+        assertEquals(MissionPackageSendStatus.INVALID_ADDRESS, result.status)
+        assertNull(result.endpoint)
+    }
+
+    @Test
+    fun `parser rejects malformed url with scheme`() {
+        val result = parser.parse("http://:8765/missions", 8765)
+
+        assertEquals(MissionPackageSendStatus.INVALID_ADDRESS, result.status)
+        assertNull(result.endpoint)
+    }
+
+    @Test
+    fun `parser builds endpoint for domain names`() {
+        val result = parser.parse("kid-reader.local", 8765)
+
+        assertEquals(MissionPackageSendStatus.SENT, result.status)
+        assertNotNull(result.endpoint)
+        assertEquals("kid-reader.local", result.endpoint?.host)
+    }
+}

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
@@ -1,7 +1,10 @@
 package com.cachekid.companion.host.mission
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.net.ServerSocket
+import java.net.Socket
 import kotlin.io.path.createTempDirectory
 
 class MissionPackageSenderClientTest {
@@ -29,10 +32,97 @@ class MissionPackageSenderClientTest {
             )
 
             assertTrue(result.isSuccess)
+            assertEquals(MissionPackageSendStatus.SENT, result.status)
             assertTrue(result.message.contains("Stored ${missionPackage.missionId}"))
             assertTrue(statusMessages.any { it.contains("Mission empfangen") })
         } finally {
             receiver.stop()
+        }
+    }
+
+    @Test
+    fun `sender client accepts pasted receiver url`() {
+        val tempDir = createTempDirectory("cachekid-sender-url").toFile()
+        val receiver = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = {},
+        )
+        val port = requireNotNull(receiver.start())
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val result = senderClient.send(
+                host = "http://127.0.0.1:$port/missions",
+                port = port,
+                missionPackage = missionPackage,
+            )
+
+            assertTrue(result.isSuccess)
+            assertEquals(MissionPackageSendStatus.SENT, result.status)
+        } finally {
+            receiver.stop()
+        }
+    }
+
+    @Test
+    fun `sender client reports missing address`() {
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+        val result = senderClient.send(
+            host = " ",
+            port = 8765,
+            missionPackage = missionPackage,
+        )
+
+        assertEquals(MissionPackageSendStatus.MISSING_ADDRESS, result.status)
+        assertTrue(result.message.contains("fehlt"))
+    }
+
+    @Test
+    fun `sender client reports invalid port`() {
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+        val result = senderClient.send(
+            host = "127.0.0.1",
+            port = 0,
+            missionPackage = missionPackage,
+        )
+
+        assertEquals(MissionPackageSendStatus.INVALID_PORT, result.status)
+        assertTrue(result.message.contains("Port"))
+    }
+
+    @Test
+    fun `sender client reports connection failure`() {
+        val unusedPort = findUnusedPort()
+        val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+        val result = senderClient.send(
+            host = "127.0.0.1",
+            port = unusedPort,
+            missionPackage = missionPackage,
+        )
+
+        assertEquals(MissionPackageSendStatus.CONNECTION_FAILED, result.status)
+        assertTrue(result.message.contains("Verbindung"))
+    }
+
+    @Test
+    fun `sender client reports http error response`() {
+        val server = SingleResponseServer(statusCode = 400, body = "Invalid mission package.")
+        val port = server.start()
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val result = senderClient.send(
+                host = "127.0.0.1",
+                port = port,
+                missionPackage = missionPackage,
+            )
+
+            assertEquals(MissionPackageSendStatus.HTTP_ERROR, result.status)
+            assertEquals(400, result.statusCode)
+            assertTrue(result.message.contains("Invalid mission package"))
+        } finally {
+            server.stop()
         }
     }
 
@@ -45,5 +135,77 @@ class MissionPackageSenderClientTest {
             target = MissionTarget(52.520008, 13.404954),
             sourceApp = "geocaching",
         )
+    }
+
+    private fun findUnusedPort(): Int {
+        ServerSocket(0).use { socket ->
+            return socket.localPort
+        }
+    }
+
+    private class SingleResponseServer(
+        private val statusCode: Int,
+        private val body: String,
+    ) {
+        private val socket = ServerSocket(0)
+        private val thread = Thread {
+            socket.accept().use { client ->
+                consumeRequest(client)
+                val statusText = if (statusCode == 200) "OK" else "Bad Request"
+                val payload = body.toByteArray(Charsets.UTF_8)
+                client.getOutputStream().write(
+                    (
+                        "HTTP/1.1 $statusCode $statusText\r\n" +
+                            "Content-Type: text/plain; charset=utf-8\r\n" +
+                            "Content-Length: ${payload.size}\r\n" +
+                            "Connection: close\r\n\r\n"
+                        ).toByteArray(Charsets.UTF_8),
+                )
+                client.getOutputStream().write(payload)
+                client.getOutputStream().flush()
+            }
+        }
+
+        fun start(): Int {
+            thread.start()
+            return socket.localPort
+        }
+
+        fun stop() {
+            socket.close()
+            thread.join(500)
+        }
+
+        private fun consumeRequest(client: Socket) {
+            val input = client.getInputStream()
+            var previous = -1
+            var current: Int
+            var headerEndMatches = 0
+            val headers = StringBuilder()
+            while (input.read().also { current = it } != -1) {
+                headers.append(current.toChar())
+                headerEndMatches = when {
+                    previous == '\r'.code && current == '\n'.code && headerEndMatches == 0 -> 1
+                    previous == '\n'.code && current == '\r'.code && headerEndMatches == 1 -> 2
+                    previous == '\r'.code && current == '\n'.code && headerEndMatches == 2 -> 3
+                    else -> headerEndMatches
+                }
+                if (headerEndMatches == 3) {
+                    break
+                }
+                previous = current
+            }
+            val contentLength = headers.lineSequence()
+                .firstOrNull { it.startsWith("Content-Length:", ignoreCase = true) }
+                ?.substringAfter(":")
+                ?.trim()
+                ?.toIntOrNull()
+                ?: 0
+            repeat(contentLength) {
+                if (input.read() == -1) {
+                    return
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Normalize receiver addresses before host-side mission transfer requests
- Add stable sender result statuses for missing/invalid address, invalid port, connection failures, timeouts, HTTP errors, and generic failures
- Add parser and sender regression tests for the hardened transfer behavior

## Tests
- ./gradlew testDebugUnitTest --tests 'com.cachekid.companion.host.mission.MissionPackageSenderClientTest' --tests 'com.cachekid.companion.host.mission.MissionPackageReceiverEndpointParserTest'
- ./gradlew testDebugUnitTest

Closes #40
Refs #30