### PR TITLE
Harden kid receiver import results

### DIFF
--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageImportResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageImportResult.kt
@@ -6,7 +6,21 @@ data class MissionPackageImportResult(
     val missionDirectory: File?,
     val missionId: String?,
     val errors: List<String>,
+    val status: MissionPackageImportStatus = if (missionDirectory != null && missionId != null && errors.isEmpty()) {
+        MissionPackageImportStatus.IMPORTED
+    } else {
+        MissionPackageImportStatus.FAILED
+    },
 ) {
     val isSuccess: Boolean
         get() = missionDirectory != null && missionId != null && errors.isEmpty()
+}
+
+enum class MissionPackageImportStatus {
+    IMPORTED,
+    ZIP_DECODE_FAILED,
+    MANIFEST_INVALID,
+    VALIDATION_FAILED,
+    STORE_FAILED,
+    FAILED,
 }

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiveResponse.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiveResponse.kt
@@ -1,0 +1,104 @@
+package com.cachekid.companion.host.mission
+
+data class MissionPackageReceiveResponse(
+    val status: MissionPackageReceiveStatus,
+    val missionId: String?,
+    val message: String,
+    val errors: List<String> = emptyList(),
+) {
+    fun toJson(): String {
+        return buildString {
+            append("{")
+            append("\"status\":\"").append(status.name).append("\",")
+            append("\"missionId\":")
+            if (missionId == null) {
+                append("null")
+            } else {
+                append("\"").append(escapeJson(missionId)).append("\"")
+            }
+            append(",\"message\":\"").append(escapeJson(message)).append("\",")
+            append("\"errors\":[")
+            errors.forEachIndexed { index, error ->
+                if (index > 0) append(",")
+                append("\"").append(escapeJson(error)).append("\"")
+            }
+            append("]}")
+        }
+    }
+
+    companion object {
+        fun parse(json: String): MissionPackageReceiveResponse? {
+            val status = extractString(json, "status")
+                ?.let { runCatching { MissionPackageReceiveStatus.valueOf(it) }.getOrNull() }
+                ?: return null
+            val message = extractString(json, "message") ?: return null
+            val missionId = extractNullableString(json, "missionId")
+            val errors = extractStringArray(json, "errors")
+            return MissionPackageReceiveResponse(
+                status = status,
+                missionId = missionId,
+                message = message,
+                errors = errors,
+            )
+        }
+
+        private fun extractString(json: String, key: String): String? {
+            val regex = Regex(""""$key"\s*:\s*"((?:\\.|[^"\\])*)"""")
+            return regex.find(json)?.groupValues?.getOrNull(1)?.unescapeJson()
+        }
+
+        private fun extractNullableString(json: String, key: String): String? {
+            if (Regex(""""$key"\s*:\s*null""").containsMatchIn(json)) {
+                return null
+            }
+            return extractString(json, key)
+        }
+
+        private fun extractStringArray(json: String, key: String): List<String> {
+            val regex = Regex(""""$key"\s*:\s*\[(.*?)]""", RegexOption.DOT_MATCHES_ALL)
+            val body = regex.find(json)?.groupValues?.getOrNull(1) ?: return emptyList()
+            return Regex(""""((?:\\.|[^"\\])*)"""")
+                .findAll(body)
+                .map { it.groupValues[1].unescapeJson() }
+                .toList()
+        }
+    }
+}
+
+enum class MissionPackageReceiveStatus {
+    IMPORTED,
+    UNSUPPORTED_ENDPOINT,
+    MISSING_LENGTH,
+    INVALID_LENGTH,
+    UNSUPPORTED_MEDIA_TYPE,
+    EMPTY_BODY,
+    INCOMPLETE_BODY,
+    INVALID_ZIP,
+    INVALID_MANIFEST,
+    VALIDATION_FAILED,
+    STORE_FAILED,
+    FAILED,
+}
+
+private fun escapeJson(value: String): String {
+    return buildString {
+        value.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> append(char)
+            }
+        }
+    }
+}
+
+private fun String.unescapeJson(): String {
+    return replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\")
+}

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverServer.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageReceiverServer.kt
@@ -6,8 +6,8 @@ import java.net.BindException
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
-import java.util.concurrent.Executors
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MissionPackageReceiverServer(
@@ -73,34 +73,123 @@ class MissionPackageReceiverServer(
         val requestParts = requestLine.split(" ")
         val method = requestParts.getOrNull(0)
         val path = requestParts.getOrNull(1)
-        val contentLength = Regex("""Content-Length:\s*(\d+)""", RegexOption.IGNORE_CASE)
+        val contentLengthHeader = Regex("""Content-Length:\s*([^\r\n]+)""", RegexOption.IGNORE_CASE)
             .find(headersText)
             ?.groupValues
             ?.getOrNull(1)
-            ?.toIntOrNull()
-            ?: 0
+            ?.trim()
+        val contentLength = contentLengthHeader?.toIntOrNull()
+        val contentType = Regex("""Content-Type:\s*([^\r\n;]+)""", RegexOption.IGNORE_CASE)
+            .find(headersText)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.trim()
+            ?.lowercase()
 
         if (method != "POST" || path != "/missions") {
-            writeResponse(output, 404, "Unsupported endpoint.")
+            writeJsonResponse(
+                output = output,
+                statusCode = 404,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.UNSUPPORTED_ENDPOINT,
+                    missionId = null,
+                    message = "Unsupported endpoint.",
+                    errors = listOf("Expected POST /missions."),
+                ),
+            )
+            return
+        }
+        if (contentLengthHeader == null) {
+            writeJsonResponse(
+                output = output,
+                statusCode = 411,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.MISSING_LENGTH,
+                    missionId = null,
+                    message = "Content-Length header is required.",
+                    errors = listOf("Mission package length is missing."),
+                ),
+            )
+            return
+        }
+        if (contentLength == null || contentLength < 0) {
+            writeJsonResponse(
+                output = output,
+                statusCode = 400,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.INVALID_LENGTH,
+                    missionId = null,
+                    message = "Content-Length header is invalid.",
+                    errors = listOf("Mission package length is invalid."),
+                ),
+            )
+            return
+        }
+        if (contentType != "application/zip") {
+            drainRequestBody(input, contentLength)
+            writeJsonResponse(
+                output = output,
+                statusCode = 415,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.UNSUPPORTED_MEDIA_TYPE,
+                    missionId = null,
+                    message = "Content-Type must be application/zip.",
+                    errors = listOf("Mission package upload must use application/zip."),
+                ),
+            )
+            return
+        }
+        if (contentLength == 0) {
+            writeJsonResponse(
+                output = output,
+                statusCode = 400,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.EMPTY_BODY,
+                    missionId = null,
+                    message = "Mission package body is empty.",
+                    errors = listOf("Mission package body is empty."),
+                ),
+            )
             return
         }
 
         val body = ByteArray(contentLength)
-        var bytesRead = 0
-        while (bytesRead < contentLength) {
-            val read = input.read(body, bytesRead, contentLength - bytesRead)
-            if (read <= 0) break
-            bytesRead += read
+        val bytesRead = readRequestBody(input, body, contentLength)
+        if (bytesRead != contentLength) {
+            writeJsonResponse(
+                output = output,
+                statusCode = 400,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.INCOMPLETE_BODY,
+                    missionId = null,
+                    message = "Mission package body ended before Content-Length bytes were received.",
+                    errors = listOf("Mission package upload was incomplete."),
+                ),
+            )
+            return
         }
 
         val result = importer.import(baseDirectory, body)
         if (result.isSuccess) {
             onStatusChanged("Mission empfangen: ${result.missionId}")
             onMissionImported(result)
-            writeResponse(output, 200, "Stored ${result.missionId}")
+            writeJsonResponse(
+                output = output,
+                statusCode = 200,
+                response = MissionPackageReceiveResponse(
+                    status = MissionPackageReceiveStatus.IMPORTED,
+                    missionId = result.missionId,
+                    message = "Mission empfangen: ${result.missionId}",
+                ),
+            )
         } else {
-            onStatusChanged(result.errors.firstOrNull() ?: "Mission-Empfang fehlgeschlagen.")
-            writeResponse(output, 400, result.errors.joinToString(" "))
+            val response = result.toReceiveResponse()
+            onStatusChanged(response.message)
+            writeJsonResponse(
+                output = output,
+                statusCode = result.toHttpStatusCode(),
+                response = response,
+            )
         }
     }
 
@@ -124,19 +213,94 @@ class MissionPackageReceiverServer(
         return headerBytes.toByteArray().toString(Charsets.UTF_8)
     }
 
-    private fun writeResponse(output: java.io.OutputStream, statusCode: Int, body: String) {
-        val statusText = if (statusCode == 200) "OK" else "Bad Request"
+    private fun drainRequestBody(input: BufferedInputStream, contentLength: Int) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var bytesRead = 0
+        while (bytesRead < contentLength) {
+            val read = input.read(buffer, 0, minOf(buffer.size, contentLength - bytesRead))
+            if (read <= 0) break
+            bytesRead += read
+        }
+    }
+
+    private fun readRequestBody(
+        input: BufferedInputStream,
+        body: ByteArray,
+        contentLength: Int,
+    ): Int {
+        var bytesRead = 0
+        while (bytesRead < contentLength) {
+            val read = input.read(body, bytesRead, contentLength - bytesRead)
+            if (read <= 0) break
+            bytesRead += read
+        }
+        return bytesRead
+    }
+
+    private fun writeJsonResponse(
+        output: java.io.OutputStream,
+        statusCode: Int,
+        response: MissionPackageReceiveResponse,
+    ) {
+        val statusText = when (statusCode) {
+            200 -> "OK"
+            400 -> "Bad Request"
+            404 -> "Not Found"
+            411 -> "Length Required"
+            415 -> "Unsupported Media Type"
+            422 -> "Unprocessable Content"
+            500 -> "Internal Server Error"
+            else -> "Error"
+        }
+        val body = response.toJson()
         val payload = body.toByteArray(Charsets.UTF_8)
         output.write(
             (
                 "HTTP/1.1 $statusCode $statusText\r\n" +
-                    "Content-Type: text/plain; charset=utf-8\r\n" +
+                    "Content-Type: application/json; charset=utf-8\r\n" +
                     "Content-Length: ${payload.size}\r\n" +
                     "Connection: close\r\n\r\n"
                 ).toByteArray(Charsets.UTF_8),
         )
         output.write(payload)
         output.flush()
+    }
+
+    private fun MissionPackageImportResult.toHttpStatusCode(): Int {
+        return when (status) {
+            MissionPackageImportStatus.ZIP_DECODE_FAILED,
+            MissionPackageImportStatus.MANIFEST_INVALID,
+            MissionPackageImportStatus.VALIDATION_FAILED,
+            -> 422
+            MissionPackageImportStatus.STORE_FAILED -> 500
+            MissionPackageImportStatus.FAILED -> 400
+            MissionPackageImportStatus.IMPORTED -> 200
+        }
+    }
+
+    private fun MissionPackageImportResult.toReceiveResponse(): MissionPackageReceiveResponse {
+        val receiveStatus = when (status) {
+            MissionPackageImportStatus.ZIP_DECODE_FAILED -> MissionPackageReceiveStatus.INVALID_ZIP
+            MissionPackageImportStatus.MANIFEST_INVALID -> MissionPackageReceiveStatus.INVALID_MANIFEST
+            MissionPackageImportStatus.VALIDATION_FAILED -> MissionPackageReceiveStatus.VALIDATION_FAILED
+            MissionPackageImportStatus.STORE_FAILED -> MissionPackageReceiveStatus.STORE_FAILED
+            MissionPackageImportStatus.FAILED -> MissionPackageReceiveStatus.FAILED
+            MissionPackageImportStatus.IMPORTED -> MissionPackageReceiveStatus.IMPORTED
+        }
+        val fallbackMessage = when (receiveStatus) {
+            MissionPackageReceiveStatus.INVALID_ZIP -> "Mission package ZIP could not be decoded."
+            MissionPackageReceiveStatus.INVALID_MANIFEST -> "Mission package manifest is missing or invalid."
+            MissionPackageReceiveStatus.VALIDATION_FAILED -> "Mission package validation failed."
+            MissionPackageReceiveStatus.STORE_FAILED -> "Mission package could not be stored."
+            MissionPackageReceiveStatus.FAILED -> "Mission-Empfang fehlgeschlagen."
+            else -> "Mission-Empfang fehlgeschlagen."
+        }
+        return MissionPackageReceiveResponse(
+            status = receiveStatus,
+            missionId = missionId,
+            message = errors.firstOrNull() ?: fallbackMessage,
+            errors = errors,
+        )
     }
 
     private companion object {

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSendResult.kt
@@ -9,6 +9,7 @@ data class MissionPackageSendResult(
     } else {
         MissionPackageSendStatus.FAILED
     },
+    val receiverStatus: MissionPackageReceiveStatus? = null,
 )
 
 enum class MissionPackageSendStatus {

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageSenderClient.kt
@@ -54,11 +54,13 @@ class MissionPackageSenderClient(
                 val stream = if (statusCode in 200..299) connection.inputStream else connection.errorStream
                 stream?.bufferedReader()?.use { it.readText() }.orEmpty()
             }.getOrDefault("")
+            val receiverResponse = MissionPackageReceiveResponse.parse(responseText)
+            val responseMessage = receiverResponse?.message ?: responseText
 
             MissionPackageSendResult(
                 isSuccess = statusCode in 200..299,
                 statusCode = statusCode,
-                message = responseText.ifBlank {
+                message = responseMessage.ifBlank {
                     if (statusCode in 200..299) "Mission gesendet." else "Transfer fehlgeschlagen."
                 },
                 status = if (statusCode in 200..299) {
@@ -66,6 +68,7 @@ class MissionPackageSenderClient(
                 } else {
                     MissionPackageSendStatus.HTTP_ERROR
                 },
+                receiverStatus = receiverResponse?.status,
             )
         }.getOrElse { error ->
             MissionPackageSendResult(

--- a/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipImporter.kt
+++ b/app/src/main/java/com/cachekid/companion/host/mission/MissionPackageZipImporter.kt
@@ -15,6 +15,15 @@ class MissionPackageZipImporter(
                 missionDirectory = null,
                 missionId = null,
                 errors = listOf("Mission package ZIP could not be decoded."),
+                status = MissionPackageImportStatus.ZIP_DECODE_FAILED,
+            )
+        }
+        if (files.isEmpty()) {
+            return MissionPackageImportResult(
+                missionDirectory = null,
+                missionId = null,
+                errors = listOf("Mission package ZIP could not be decoded."),
+                status = MissionPackageImportStatus.ZIP_DECODE_FAILED,
             )
         }
 
@@ -22,6 +31,7 @@ class MissionPackageZipImporter(
             missionDirectory = null,
             missionId = null,
             errors = listOf("Mission package manifest is missing or invalid."),
+            status = MissionPackageImportStatus.MANIFEST_INVALID,
         )
 
         val validation = validator.validate(missionPackage)
@@ -30,6 +40,7 @@ class MissionPackageZipImporter(
                 missionDirectory = null,
                 missionId = missionPackage.missionId,
                 errors = validation.errors,
+                status = MissionPackageImportStatus.VALIDATION_FAILED,
             )
         }
 
@@ -38,6 +49,11 @@ class MissionPackageZipImporter(
             missionDirectory = storeResult.missionDirectory,
             missionId = missionPackage.missionId,
             errors = storeResult.errors,
+            status = if (storeResult.isSuccess) {
+                MissionPackageImportStatus.IMPORTED
+            } else {
+                MissionPackageImportStatus.STORE_FAILED
+            },
         )
     }
 }

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverServerTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageReceiverServerTest.kt
@@ -1,5 +1,6 @@
 package com.cachekid.companion.host.mission
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -27,12 +28,147 @@ class MissionPackageReceiverServerTest {
             val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
             val zipBytes = zipCodec.encode(missionPackage)
             val response = sendHttpPost(port, zipBytes)
+            val body = response.substringAfter("\r\n\r\n")
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(body))
 
             assertTrue(response.contains("200 OK"))
-            assertTrue(response.contains("Stored ${missionPackage.missionId}"))
+            assertEquals(MissionPackageReceiveStatus.IMPORTED, receiveResponse.status)
+            assertEquals(missionPackage.missionId, receiveResponse.missionId)
+            assertTrue(receiveResponse.message.contains("Mission empfangen"))
             assertTrue(statusMessages.any { it.contains("Mission empfangen") })
         } finally {
             server.stop()
+        }
+    }
+
+    @Test
+    fun `receiver server rejects unsupported endpoints with machine-readable response`() {
+        val tempDir = createTempDirectory("cachekid-receiver-endpoint").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = {},
+        )
+        val port = requireNotNull(server.start())
+
+        try {
+            val response = sendHttpRequest(
+                port = port,
+                method = "GET",
+                path = "/status",
+                body = ByteArray(0),
+                includeContentLength = true,
+            )
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(response.substringAfter("\r\n\r\n")))
+
+            assertTrue(response.contains("404 Not Found"))
+            assertEquals(MissionPackageReceiveStatus.UNSUPPORTED_ENDPOINT, receiveResponse.status)
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `receiver server rejects missing content length`() {
+        val tempDir = createTempDirectory("cachekid-receiver-length").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = {},
+        )
+        val port = requireNotNull(server.start())
+
+        try {
+            val response = sendHttpRequest(
+                port = port,
+                method = "POST",
+                path = "/missions",
+                body = ByteArray(0),
+                includeContentLength = false,
+            )
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(response.substringAfter("\r\n\r\n")))
+
+            assertTrue(response.contains("411 Length Required"))
+            assertEquals(MissionPackageReceiveStatus.MISSING_LENGTH, receiveResponse.status)
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `receiver server rejects unsupported content type`() {
+        val tempDir = createTempDirectory("cachekid-receiver-content-type").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = {},
+        )
+        val port = requireNotNull(server.start())
+
+        try {
+            val response = sendHttpRequest(
+                port = port,
+                method = "POST",
+                path = "/missions",
+                body = byteArrayOf(1, 2, 3),
+                contentType = "text/plain",
+            )
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(response.substringAfter("\r\n\r\n")))
+
+            assertTrue(response.contains("415 Unsupported Media Type"))
+            assertEquals(MissionPackageReceiveStatus.UNSUPPORTED_MEDIA_TYPE, receiveResponse.status)
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `receiver server reports invalid zip packages`() {
+        val statusMessages = mutableListOf<String>()
+        val tempDir = createTempDirectory("cachekid-receiver-invalid-zip").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = tempDir,
+            port = 0,
+            onStatusChanged = { statusMessages.add(it) },
+        )
+        val port = requireNotNull(server.start())
+
+        try {
+            val response = sendHttpPost(port, "not a zip".toByteArray(Charsets.UTF_8))
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(response.substringAfter("\r\n\r\n")))
+
+            assertTrue(response.contains("422 Unprocessable Content"))
+            assertEquals(MissionPackageReceiveStatus.INVALID_ZIP, receiveResponse.status)
+            assertTrue(receiveResponse.errors.any { it.contains("ZIP") })
+            assertTrue(statusMessages.any { it.contains("ZIP") })
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `receiver server reports store failures separately from invalid packages`() {
+        val statusMessages = mutableListOf<String>()
+        val basePath = kotlin.io.path.createTempFile("cachekid-receiver-store-failure").toFile()
+        val server = MissionPackageReceiverServer(
+            baseDirectory = basePath,
+            port = 0,
+            onStatusChanged = { statusMessages.add(it) },
+        )
+        val port = requireNotNull(server.start())
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val response = sendHttpPost(port, zipCodec.encode(missionPackage))
+            val receiveResponse = requireNotNull(MissionPackageReceiveResponse.parse(response.substringAfter("\r\n\r\n")))
+
+            assertTrue(response.contains("500 Internal Server Error"))
+            assertEquals(MissionPackageReceiveStatus.STORE_FAILED, receiveResponse.status)
+            assertEquals(missionPackage.missionId, receiveResponse.missionId)
+            assertTrue(statusMessages.any { it.contains("storage") })
+        } finally {
+            server.stop()
+            basePath.delete()
         }
     }
 
@@ -66,14 +202,35 @@ class MissionPackageReceiverServerTest {
     }
 
     private fun sendHttpPost(port: Int, body: ByteArray): String {
+        return sendHttpRequest(
+            port = port,
+            method = "POST",
+            path = "/missions",
+            body = body,
+        )
+    }
+
+    private fun sendHttpRequest(
+        port: Int,
+        method: String,
+        path: String,
+        body: ByteArray,
+        contentType: String = "application/zip",
+        includeContentLength: Boolean = true,
+    ): String {
         Socket("127.0.0.1", port).use { socket ->
             val output = socket.getOutputStream()
+            val contentLengthHeader = if (includeContentLength) {
+                "Content-Length: ${body.size}\r\n"
+            } else {
+                ""
+            }
             output.write(
                 (
-                    "POST /missions HTTP/1.1\r\n" +
+                    "$method $path HTTP/1.1\r\n" +
                         "Host: 127.0.0.1\r\n" +
-                        "Content-Type: application/zip\r\n" +
-                        "Content-Length: ${body.size}\r\n" +
+                        "Content-Type: $contentType\r\n" +
+                        contentLengthHeader +
                         "Connection: close\r\n\r\n"
                     ).toByteArray(Charsets.UTF_8),
             )

--- a/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
+++ b/app/src/test/java/com/cachekid/companion/host/mission/MissionPackageSenderClientTest.kt
@@ -33,7 +33,9 @@ class MissionPackageSenderClientTest {
 
             assertTrue(result.isSuccess)
             assertEquals(MissionPackageSendStatus.SENT, result.status)
-            assertTrue(result.message.contains("Stored ${missionPackage.missionId}"))
+            assertEquals(MissionPackageReceiveStatus.IMPORTED, result.receiverStatus)
+            assertTrue(result.message.contains("Mission empfangen"))
+            assertTrue(result.message.contains(missionPackage.missionId))
             assertTrue(statusMessages.any { it.contains("Mission empfangen") })
         } finally {
             receiver.stop()
@@ -126,6 +128,37 @@ class MissionPackageSenderClientTest {
         }
     }
 
+    @Test
+    fun `sender client maps receiver json error response`() {
+        val receiverResponse = MissionPackageReceiveResponse(
+            status = MissionPackageReceiveStatus.INVALID_ZIP,
+            missionId = null,
+            message = "Mission package ZIP could not be decoded.",
+            errors = listOf("Mission package ZIP could not be decoded."),
+        )
+        val server = SingleResponseServer(
+            statusCode = 422,
+            body = receiverResponse.toJson(),
+            contentType = "application/json; charset=utf-8",
+        )
+        val port = server.start()
+
+        try {
+            val missionPackage = requireNotNull(writer.write(validDraft()).missionPackage)
+            val result = senderClient.send(
+                host = "127.0.0.1",
+                port = port,
+                missionPackage = missionPackage,
+            )
+
+            assertEquals(MissionPackageSendStatus.HTTP_ERROR, result.status)
+            assertEquals(MissionPackageReceiveStatus.INVALID_ZIP, result.receiverStatus)
+            assertEquals("Mission package ZIP could not be decoded.", result.message)
+        } finally {
+            server.stop()
+        }
+    }
+
     private fun validDraft(): MissionDraft {
         return MissionDraft(
             cacheCode = "GC12345",
@@ -146,6 +179,7 @@ class MissionPackageSenderClientTest {
     private class SingleResponseServer(
         private val statusCode: Int,
         private val body: String,
+        private val contentType: String = "text/plain; charset=utf-8",
     ) {
         private val socket = ServerSocket(0)
         private val thread = Thread {
@@ -156,7 +190,7 @@ class MissionPackageSenderClientTest {
                 client.getOutputStream().write(
                     (
                         "HTTP/1.1 $statusCode $statusText\r\n" +
-                            "Content-Type: text/plain; charset=utf-8\r\n" +
+                            "Content-Type: $contentType\r\n" +
                             "Content-Length: ${payload.size}\r\n" +
                             "Connection: close\r\n\r\n"
                         ).toByteArray(Charsets.UTF_8),


### PR DESCRIPTION
## Summary
- Add structured receiver JSON responses with stable import/request statuses
- Distinguish invalid ZIP, invalid manifest, validation failure, store failure, unsupported endpoint, missing/invalid length, unsupported media type, empty body, and incomplete body
- Parse receiver JSON in the host sender so UI-facing send results can expose the receiver status without raw JSON

## Tests
- ./gradlew testDebugUnitTest --tests 'com.cachekid.companion.host.mission.MissionPackageReceiverServerTest' --tests 'com.cachekid.companion.host.mission.MissionPackageSenderClientTest' --tests 'com.cachekid.companion.host.mission.MissionPackageZipImporterTest'
- ./gradlew testDebugUnitTest

Closes #41
Refs #30