### PR TITLE
Allow local mission transfer cleartext

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:usesCleartextTraffic="true"
         android:supportsRtl="true"
         android:theme="@style/Theme.CacheKidCompanion">
         <activity

--- a/docs/real-device-transfer-test.md
+++ b/docs/real-device-transfer-test.md
@@ -36,6 +36,7 @@ Network:
 - both devices must be on the same Wi-Fi or hotspot network
 - client isolation must be disabled on the network
 - the host must be able to reach the kid device on TCP port `8765`
+- the app intentionally permits cleartext HTTP because the MVP receiver uses local `http://<kid-ip>:8765/missions`
 
 Build:
 
@@ -151,6 +152,7 @@ Host-side expected failures:
 | Blank address | `Empfangsadresse fehlt.` |
 | Invalid port | `Port ist ungueltig.` |
 | Wrong IP or receiver stopped | connection failure message |
+| Cleartext HTTP blocked | app build is missing the intentional local-transfer cleartext permission |
 | Kid rejects package | HTTP error with the kid receiver message |
 | Timeout | timeout message |
 


### PR DESCRIPTION
## Summary
- Allow intentional cleartext HTTP for the explicit-address local mission transfer MVP
- Document the cleartext requirement and failure mode in the real-device transfer runbook

## Validation
- Built debug APK with ./gradlew assembleDebug
- Installed on Meebook M6
- Verified host-to-kid transfer to 192.168.188.117:8765 succeeds after the fix
- git diff --check

No unit test added because this is Android manifest/network-policy configuration plus documentation.

Refs #39
Refs #30