### PR TITLE
fix(#54): include all route points in maximizeZoomForVisibleEndpoints

### DIFF
--- a/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
@@ -391,8 +391,7 @@ class KidNativeMapController(
             map.moveCamera(update)
             maximizeZoomForVisibleEndpoints(
                 map = map,
-                routeStart = routeStart,
-                missionTarget = missionTarget,
+                routePoints = routePoints,
                 width = width,
                 height = height,
                 topPadding = topPadding,
@@ -869,8 +868,7 @@ class KidNativeMapController(
 
     private fun maximizeZoomForVisibleEndpoints(
         map: MapLibreMap,
-        routeStart: LatLng,
-        missionTarget: LatLng,
+        routePoints: List<LatLng>,
         width: Int,
         height: Int,
         topPadding: Int,
@@ -895,17 +893,13 @@ class KidNativeMapController(
                 .build()
             map.moveCamera(CameraUpdateFactory.newCameraPosition(candidateCamera))
 
-            val originPoint = map.projection.toScreenLocation(routeStart)
-            val targetPoint = map.projection.toScreenLocation(missionTarget)
-            val fits =
-                originPoint.x >= left + safetyInset &&
-                    originPoint.x <= right - safetyInset &&
-                    originPoint.y >= top + safetyInset &&
-                    originPoint.y <= bottom - safetyInset &&
-                    targetPoint.x >= left + safetyInset &&
-                    targetPoint.x <= right - safetyInset &&
-                    targetPoint.y >= top + safetyInset &&
-                    targetPoint.y <= bottom - safetyInset
+            val fits = routePoints.all { point ->
+                val screenPoint = map.projection.toScreenLocation(point)
+                screenPoint.x >= left + safetyInset &&
+                    screenPoint.x <= right - safetyInset &&
+                    screenPoint.y >= top + safetyInset &&
+                    screenPoint.y <= bottom - safetyInset
+            }
 
             if (!fits) {
                 map.moveCamera(CameraUpdateFactory.newCameraPosition(currentCamera))


### PR DESCRIPTION
maximizeZoomForVisibleEndpoints() previously only checked that routeStart and missionTarget remained inside the padded viewport. Intermediate waypoints were ignored, causing the player origin (O) or waypoints to be clipped when the route bent away from the straight line between endpoints.

Changes:
- Function signature now accepts routePoints: List<LatLng>
- Visibility check iterates over all routePoints with .all {}
- Call site in updateCamera() passes the full routePoints list

The bearing-refit path (refitZoomForCurrentBearing → solveRouteCameraForCurrentBearing) was already correct; this fix brings the initial non-bearing path into alignment.

Unit tests: BUILD SUCCESSFUL

## Summary

- What changed?
- Why now?

## Professional standard

- [ ] Planned and scoped before implementation
- [ ] Keeps the codebase maintainable and scalable
- [ ] Includes necessary refactoring instead of pushing debt forward silently
- [ ] Includes a meaningful automated test case for the changed behavior, or explains why that is not yet practical

## Issue

- Closes #

## Validation

- [ ] `frontend-tests`
- [ ] `android-tests`
- [ ] Added or updated automated tests
- [ ] Manual verification noted where automation is not yet possible

## Architecture

- [ ] Logic kept in testable modules
- [ ] Refactors included where needed to avoid code sprawl
- [ ] Follow-up issues created for intentionally deferred work

## Risk

- User-facing risk:
- Rollback path:
