### PR TITLE
Fix #65 #59: Heading-Up Follow-Mode mit dynamischem Zoom

### DIFF
--- a/app/src/main/java/com/cachekid/companion/kid/KidMapCameraPlanner.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidMapCameraPlanner.kt
@@ -1,57 +1,54 @@
 package com.cachekid.companion.kid
 
 import com.cachekid.companion.host.mission.ActiveMission
-import com.cachekid.companion.host.mission.MissionTarget
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.geometry.LatLngBounds
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
 
-/**
- * Pure Kotlin camera planner for the kid map.
- *
- * Decides target, bearing, zoom and tilt based on camera mode,
- * live location, heading and mission geometry.  Contains no
- * Android or MapLibre dependencies so it can be unit-tested.
- */
+enum class CameraMode {
+    ROUTE_OVERVIEW,
+    FOLLOW_HEADING_UP,
+}
+
+data class CameraPlan(
+    val mode: CameraMode,
+    val target: LatLng? = null,
+    val bounds: LatLngBounds? = null,
+    val zoom: Double? = null,
+    val bearing: Double = 0.0,
+    val tilt: Double = 0.0,
+)
+
+data class Viewport(
+    val widthPx: Int,
+    val heightPx: Int,
+    val topPaddingPx: Int = 0,
+    val bottomPaddingPx: Int = 0,
+    val leftPaddingPx: Int = 0,
+    val rightPaddingPx: Int = 0,
+)
+
 class KidMapCameraPlanner {
 
-    enum class CameraMode {
-        /** Show the full route (start → waypoints → target). */
-        ROUTE_OVERVIEW,
-
-        /** Follow the user's live location, heading points up. */
-        FOLLOW_HEADING_UP,
+    companion object {
+        const val MIN_FOLLOW_ZOOM = 10.0
+        const val MAX_FOLLOW_ZOOM = 18.0
+        const val OVERVIEW_MIN_ZOOM = 8.5
+        const val OVERVIEW_MAX_ZOOM = 19.2
+        private const val EARTH_RADIUS_METERS = 6_371_000.0
+        private const val EARTH_CIRCUMFERENCE_METERS = 40_075_016.686
+        private const val TILE_SIZE_PX = 1024.0
+        private const val DESIRED_ORIGIN_SCREEN_FRACTION = 0.85
+        private const val DESIRED_TARGET_SCREEN_FRACTION = 0.333
     }
 
-    data class LatLng(val latitude: Double, val longitude: Double)
-
-    data class CameraPlan(
-        val target: LatLng,
-        val bearing: Double,
-        val zoom: Double,
-        val tilt: Double,
-    )
-
-    data class Viewport(
-        val widthPx: Int,
-        val heightPx: Int,
-        val topPaddingPx: Int,
-        val bottomPaddingPx: Int,
-        val sidePaddingPx: Int,
-    )
-
-    data class LocationSnapshot(
-        val latitude: Double,
-        val longitude: Double,
-        val accuracyMeters: Float,
-    )
-
-    /**
-     * Compute the desired camera state.
-     *
-     * @param mode current camera mode
-     * @param location latest known location, or null
-     * @param headingDegrees latest known heading, or null
-     * @param mission active mission, or null
-     * @param viewport current viewport metrics
-     */
     fun plan(
         mode: CameraMode,
         location: LocationSnapshot?,
@@ -60,30 +57,25 @@ class KidMapCameraPlanner {
         viewport: Viewport,
     ): CameraPlan {
         return when (mode) {
-            CameraMode.ROUTE_OVERVIEW -> planRouteOverview(location, headingDegrees, mission, viewport)
+            CameraMode.ROUTE_OVERVIEW -> planRouteOverview(location, mission, viewport)
             CameraMode.FOLLOW_HEADING_UP -> planFollowHeadingUp(location, headingDegrees, mission, viewport)
         }
     }
 
     private fun planRouteOverview(
         location: LocationSnapshot?,
-        headingDegrees: Double?,
         mission: ActiveMission?,
         viewport: Viewport,
     ): CameraPlan {
-        val fallbackTarget = mission?.target?.let { LatLng(it.latitude, it.longitude) }
-            ?: LatLng(52.52, 13.405)
-
-        val fallbackBearing = headingDegrees
-            ?: courseBearing(location, mission)
-            ?: routeBearing(mission)
-            ?: 0.0
+        val routePoints = buildRoutePoints(location, mission)
+        val bounds = latLngBoundsForPoints(routePoints)
+            ?: LatLngBounds.from(52.52, 13.405, 52.52, 13.405)
 
         return CameraPlan(
-            target = fallbackTarget,
-            bearing = normalizeDegrees(fallbackBearing),
-            zoom = 16.2,
-            tilt = 20.0,
+            mode = CameraMode.ROUTE_OVERVIEW,
+            bounds = bounds,
+            bearing = 0.0,
+            tilt = 0.0,
         )
     }
 
@@ -93,113 +85,228 @@ class KidMapCameraPlanner {
         mission: ActiveMission?,
         viewport: Viewport,
     ): CameraPlan {
-        val playerLocation = if (location != null) {
-            LatLng(location.latitude, location.longitude)
-        } else {
-            LatLng(52.52, 13.405)
-        }
-
-        val bearing = headingDegrees ?: 0.0
-
-        if (location == null || mission == null) {
+        if (mission == null) {
             return CameraPlan(
-                target = playerLocation,
-                bearing = normalizeDegrees(bearing),
-                zoom = FOLLOW_ZOOM,
+                mode = CameraMode.FOLLOW_HEADING_UP,
+                target = LatLng(52.52, 13.405),
+                zoom = MIN_FOLLOW_ZOOM,
+                bearing = normalizeDegrees(headingDegrees ?: 0.0),
                 tilt = 0.0,
             )
         }
 
+        val playerLocation = if (location != null) {
+            LatLng(location.latitude, location.longitude)
+        } else if (mission.routeOrigin != null && mission.routeOrigin.isValid()) {
+            LatLng(mission.routeOrigin.latitude, mission.routeOrigin.longitude)
+        } else {
+            LatLng(mission.target.latitude, mission.target.longitude)
+        }
+
         val targetLocation = LatLng(mission.target.latitude, mission.target.longitude)
+
+        // Spieler direkt auf Ziel → maximal reinzoomen, Target = Zielposition
+        if (playerLocation.latitude == targetLocation.latitude &&
+            playerLocation.longitude == targetLocation.longitude
+        ) {
+            return CameraPlan(
+                mode = CameraMode.FOLLOW_HEADING_UP,
+                target = targetLocation,
+                zoom = MAX_FOLLOW_ZOOM,
+                bearing = normalizeDegrees(headingDegrees ?: 0.0),
+                tilt = 0.0,
+            )
+        }
+
+        val effectiveHeading = headingDegrees ?: bearingBetween(playerLocation, targetLocation)
+
+        val playerM = latLngToMercator(playerLocation)
+        val targetM = latLngToMercator(targetLocation)
+
+        // Wenn die Distanz groß ist und das Target fast in Blickrichtung liegt,
+        // würden die Punkte im Heading-Up-Frame fast übereinander liegen.
+        // In diesem Fall auf Overview umschalten für maximale Spannweite.
         val distanceMeters = haversineDistance(
             playerLocation.latitude, playerLocation.longitude,
             targetLocation.latitude, targetLocation.longitude,
         )
-        val zoom = followZoomForDistance(distanceMeters, viewport)
+        val bearingToTarget = bearingBetween(playerLocation, targetLocation)
+        val headingTargetDiff = headingDelta(effectiveHeading, bearingToTarget)
+        // Wenn Distanz > 5km UND Target innerhalb von 30° der Blickrichtung
+        if (distanceMeters > 5000.0 && headingTargetDiff < 30.0) {
+            return planRouteOverview(location, mission, viewport)
+        }
+
+        // Relative Position im rotierten System (Heading-Up)
+        val dx = targetM.first - playerM.first
+        val dy = targetM.second - playerM.second
+
+        val angleRad = Math.toRadians(effectiveHeading)
+        val cosAngle = cos(angleRad)
+        val sinAngle = sin(angleRad)
+        val dxR = dx * cosAngle - dy * sinAngle
+        val dyR = dx * sinAngle + dy * cosAngle
+
+        val boundsWidth = kotlin.math.abs(dxR)
+        val boundsHeight = kotlin.math.abs(dyR)
+
+        val effectiveTopPx = max(viewport.topPaddingPx, (viewport.heightPx / 3.0).toInt())
+        val effectiveBottomPx = viewport.bottomPaddingPx
+        val visibleWidthPx = (viewport.widthPx - viewport.leftPaddingPx - viewport.rightPaddingPx)
+            .coerceAtLeast(100)
+        val visibleHeightPx = (viewport.heightPx - effectiveTopPx - effectiveBottomPx)
+            .coerceAtLeast(100)
+
+        val scale0 = TILE_SIZE_PX / EARTH_CIRCUMFERENCE_METERS
+
+        val zoomX = if (boundsWidth > 0.0) {
+            ln(visibleWidthPx * 0.92 / (boundsWidth * scale0)) / ln(2.0)
+        } else {
+            Double.POSITIVE_INFINITY
+        }
+        val zoomY = if (boundsHeight > 0.0) {
+            ln(visibleHeightPx * 0.92 / (boundsHeight * scale0)) / ln(2.0)
+        } else {
+            Double.POSITIVE_INFINITY
+        }
+        val zoom = min(zoomX, zoomY).coerceAtMost(MAX_FOLLOW_ZOOM)
+
+        val scale = scale0 * 2.0.pow(zoom)
+
+        // Höhe der Bounds in Pixeln bei diesem Zoom
+        val boundsHeightPixels = boundsHeight * scale
+
+        // Ideal-Mittelpunkt zwischen O und X auf dem Screen
+        val desiredMidScreenY = viewport.heightPx *
+            (DESIRED_ORIGIN_SCREEN_FRACTION + DESIRED_TARGET_SCREEN_FRACTION) / 2.0
+
+        // Clamp auf den sichtbaren Bereich, damit beide Punkte immer im Screen bleiben
+        val effectiveBoundsHeight = min(boundsHeightPixels, visibleHeightPx.toDouble())
+        val minMidY = effectiveTopPx + effectiveBoundsHeight / 2.0
+        val maxMidY = viewport.heightPx - effectiveBottomPx - effectiveBoundsHeight / 2.0
+        val actualMidScreenY = when {
+            minMidY > maxMidY -> (effectiveTopPx + viewport.heightPx - effectiveBottomPx) / 2.0
+            else -> desiredMidScreenY.coerceIn(minMidY, maxMidY)
+        }
+
+        // Target im rotierten Mercator-System (relativ zu O)
+        val targetRelX = dxR / 2.0
+        val targetRelY = dyR / 2.0 + (actualMidScreenY - viewport.heightPx / 2.0) / scale
+
+        // Rotiere zurück ins Welt-Mercator-System (Inverse der Vorwärtsrotation)
+        val backAngleRad = Math.toRadians(-effectiveHeading)
+        val cosBack = cos(backAngleRad)
+        val sinBack = sin(backAngleRad)
+        val targetRelM_x = targetRelX * cosBack - targetRelY * sinBack
+        val targetRelM_y = targetRelX * sinBack + targetRelY * cosBack
+
+        val cameraTarget = mercatorToLatLng(
+            playerM.first + targetRelM_x,
+            playerM.second + targetRelM_y,
+        )
 
         return CameraPlan(
-            target = playerLocation,
-            bearing = normalizeDegrees(bearing),
+            mode = CameraMode.FOLLOW_HEADING_UP,
+            target = cameraTarget,
             zoom = zoom,
+            bearing = normalizeDegrees(effectiveHeading),
             tilt = 0.0,
         )
     }
 
-    private fun haversineDistance(
-        lat1: Double, lon1: Double,
-        lat2: Double, lon2: Double,
-    ): Double {
+    private fun buildRoutePoints(location: LocationSnapshot?, mission: ActiveMission?): List<LatLng> {
+        if (mission == null) return emptyList()
+        val result = mutableListOf<LatLng>()
+
+        val routeOrigin = mission.routeOrigin
+        if (routeOrigin != null && routeOrigin.isValid()) {
+            result.add(LatLng(routeOrigin.latitude, routeOrigin.longitude))
+        } else if (location != null) {
+            result.add(LatLng(location.latitude, location.longitude))
+        }
+
+        mission.waypoints.forEach { waypoint ->
+            if (waypoint.isValid()) {
+                result.add(LatLng(waypoint.latitude, waypoint.longitude))
+            }
+        }
+
+        if (mission.target.isValid()) {
+            result.add(LatLng(mission.target.latitude, mission.target.longitude))
+        }
+
+        return result
+    }
+
+    private fun latLngBoundsForPoints(points: List<LatLng>): LatLngBounds? {
+        if (points.isEmpty()) return null
+        var minLat = points[0].latitude
+        var maxLat = points[0].latitude
+        var minLon = points[0].longitude
+        var maxLon = points[0].longitude
+        for (point in points.drop(1)) {
+            minLat = min(minLat, point.latitude)
+            maxLat = max(maxLat, point.latitude)
+            minLon = min(minLon, point.longitude)
+            maxLon = max(maxLon, point.longitude)
+        }
+        if (minLat == maxLat && minLon == maxLon) {
+            val pad = 0.001
+            return LatLngBounds.from(maxLat + pad, maxLon + pad, minLat - pad, minLon - pad)
+        }
+        return LatLngBounds.from(maxLat, maxLon, minLat, minLon)
+    }
+
+    private fun latLngToMercator(latLng: LatLng): Pair<Double, Double> {
+        val x = Math.toRadians(latLng.longitude) * EARTH_RADIUS_METERS
+        val y = ln(
+            kotlin.math.tan(Math.PI / 4.0 + Math.toRadians(latLng.latitude) / 2.0)
+        ) * EARTH_RADIUS_METERS
+        return x to y
+    }
+
+    private fun mercatorToLatLng(x: Double, y: Double): LatLng {
+        val lon = Math.toDegrees(x / EARTH_RADIUS_METERS)
+        val lat = Math.toDegrees(
+            2.0 * kotlin.math.atan(kotlin.math.exp(y / EARTH_RADIUS_METERS)) - Math.PI / 2.0
+        )
+        return LatLng(lat, lon)
+    }
+
+    fun haversineDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
         val dLat = Math.toRadians(lat2 - lat1)
         val dLon = Math.toRadians(lon2 - lon1)
-        val a = kotlin.math.sin(dLat / 2) * kotlin.math.sin(dLat / 2) +
-            kotlin.math.cos(Math.toRadians(lat1)) * kotlin.math.cos(Math.toRadians(lat2)) *
-            kotlin.math.sin(dLon / 2) * kotlin.math.sin(dLon / 2)
-        val c = 2 * kotlin.math.atan2(kotlin.math.sqrt(a), kotlin.math.sqrt(1 - a))
+        val a = sin(dLat / 2).pow(2) +
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(dLon / 2).pow(2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
         return EARTH_RADIUS_METERS * c
     }
 
-    private fun followZoomForDistance(distanceMeters: Double, viewport: Viewport): Double {
-        val visibleHeightPx = (viewport.heightPx - viewport.topPaddingPx - viewport.bottomPaddingPx)
-            .coerceAtLeast(100)
-        val desiredVisibleHeightMeters = distanceMeters / 0.7
-        val zoom = kotlin.math.ln(
-            visibleHeightPx * EARTH_CIRCUMFERENCE_METERS / (256.0 * desiredVisibleHeightMeters)
-        ) / kotlin.math.ln(2.0)
-        return zoom.coerceIn(MIN_FOLLOW_ZOOM, MAX_FOLLOW_ZOOM)
+    fun bearingBetween(start: LatLng, end: LatLng): Double {
+        val startLat = Math.toRadians(start.latitude)
+        val startLon = Math.toRadians(start.longitude)
+        val endLat = Math.toRadians(end.latitude)
+        val endLon = Math.toRadians(end.longitude)
+        val dLon = endLon - startLon
+        val y = sin(dLon) * cos(endLat)
+        val x = cos(startLat) * sin(endLat) - sin(startLat) * cos(endLat) * cos(dLon)
+        return normalizeDegrees(Math.toDegrees(atan2(y, x)))
     }
 
-    private fun courseBearing(
-        location: LocationSnapshot?,
-        mission: ActiveMission?,
-    ): Double? {
-        if (location == null || mission == null) return null
-        // Simplified: bearing from location to mission target
-        return bearingBetween(
-            location.latitude,
-            location.longitude,
-            mission.target.latitude,
-            mission.target.longitude,
-        )
+    fun normalizeDegrees(value: Double): Double {
+        var result = value % 360.0
+        if (result < 0) result += 360.0
+        return result
     }
 
-    private fun routeBearing(mission: ActiveMission?): Double? {
-        if (mission == null) return null
-        val origin = mission.routeOrigin ?: return null
-        return bearingBetween(
-            origin.latitude,
-            origin.longitude,
-            mission.target.latitude,
-            mission.target.longitude,
-        )
-    }
-
-    companion object {
-        const val FOLLOW_ZOOM = 18.0
-        private const val EARTH_RADIUS_METERS = 6_371_000.0
-        private const val EARTH_CIRCUMFERENCE_METERS = 40_075_016.686
-        private const val MIN_FOLLOW_ZOOM = 14.5
-        private const val MAX_FOLLOW_ZOOM = 18.0
-
-        fun normalizeDegrees(value: Double): Double {
-            var result = value % 360.0
-            if (result < 0) result += 360.0
-            return result
-        }
-
-        fun bearingBetween(
-            lat1: Double,
-            lon1: Double,
-            lat2: Double,
-            lon2: Double,
-        ): Double {
-            val lat1Rad = Math.toRadians(lat1)
-            val lat2Rad = Math.toRadians(lat2)
-            val deltaLonRad = Math.toRadians(lon2 - lon1)
-            val y = kotlin.math.sin(deltaLonRad) * kotlin.math.cos(lat2Rad)
-            val x = kotlin.math.cos(lat1Rad) * kotlin.math.sin(lat2Rad) -
-                kotlin.math.sin(lat1Rad) * kotlin.math.cos(lat2Rad) * kotlin.math.cos(deltaLonRad)
-            val bearingRad = kotlin.math.atan2(y, x)
-            return normalizeDegrees(Math.toDegrees(bearingRad))
-        }
+    /** Kleinster Winkel zwischen zwei Heading-Werten (0–180°) */
+    fun headingDelta(a: Double, b: Double): Double {
+        val diff = kotlin.math.abs(normalizeDegrees(a) - normalizeDegrees(b))
+        return if (diff > 180.0) 360.0 - diff else diff
     }
 }
+
+data class LocationSnapshot(
+    val latitude: Double,
+    val longitude: Double,
+)

--- a/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
@@ -83,24 +83,17 @@ class KidNativeMapController(
     private var currentMission: ActiveMission? = null
     private var currentLocation: Location? = null
     private var currentHeadingDegrees: Float? = null
-    private var previousCourseLocation: Location? = null
-    private var currentCourseBearingDegrees: Double? = null
     private var lastAppliedBearingDegrees: Double? = null
-    private var lastOrientationCommitAtMillis: Long = 0L
     private var displayedMissionId: String? = null
     private var displayedRouteStart: LatLng? = null
     private var displayedStyleKey: String? = null
     private var lastCameraDebugInfo: CameraDebugInfo? = null
     private var viewportTopInsetPx: Float? = null
     private var viewportBottomInsetPx: Float? = null
-    private var lastZoneFitUsedStrict = true
     private val sourceIndicatorView: ImageView
     private val cameraPlanner = KidMapCameraPlanner()
-    private var cameraMode = KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW
-    private var isCameraAnimating = false
-    private var cameraModeToggleView: ImageView? = null
-    private val arrivalImageView: ImageView
-    private var isArrivalShowing = false
+    private var currentCameraMode: CameraMode = CameraMode.ROUTE_OVERVIEW
+    private lateinit var cameraModeToggleView: android.widget.TextView
 
     init {
         MapLibre.getInstance(context.applicationContext)
@@ -141,37 +134,30 @@ class KidNativeMapController(
         overlayContainer.addView(sourceIndicatorView)
         sourceIndicatorView.bringToFront()
 
-        // Camera mode toggle button (bottom-start, opposite the source indicator)
-        cameraModeToggleView = ImageView(context).apply {
-            layoutParams = FrameLayout.LayoutParams(cardSizePx, cardSizePx).apply {
+        val toggleSizePx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP, 48f, context.resources.displayMetrics,
+        ).toInt()
+        val toggleMarginPx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP, 12f, context.resources.displayMetrics,
+        ).toInt()
+        cameraModeToggleView = android.widget.TextView(context).apply {
+            layoutParams = FrameLayout.LayoutParams(toggleSizePx, toggleSizePx).apply {
                 gravity = android.view.Gravity.BOTTOM or android.view.Gravity.START
-                bottomMargin = marginPx
-                leftMargin = marginPx
+                bottomMargin = toggleMarginPx
+                leftMargin = toggleMarginPx
             }
-            setBackgroundColor(Color.parseColor("#FFFDF8"))
+            text = "O"
+            textSize = 20f
+            setTextColor(Color.BLACK)
+            gravity = android.view.Gravity.CENTER
+            setBackgroundColor(Color.WHITE)
             elevation = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, 8f, context.resources.displayMetrics,
+                TypedValue.COMPLEX_UNIT_DIP, 4f, context.resources.displayMetrics,
             )
-            scaleType = ImageView.ScaleType.CENTER_INSIDE
-            visibility = View.GONE
             setOnClickListener { toggleCameraMode() }
         }
         overlayContainer.addView(cameraModeToggleView)
-        cameraModeToggleView?.bringToFront()
-        updateCameraModeToggleIcon()
-
-        // Arrival overlay (cacheClose.png) – fullscreen, hidden by default
-        arrivalImageView = ImageView(context).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT,
-            )
-            visibility = View.GONE
-            scaleType = ImageView.ScaleType.FIT_CENTER
-            setImageBitmap(loadBitmapFromAssets(context, "web/cacheClose.png"))
-        }
-        overlayContainer.addView(arrivalImageView)
-        arrivalImageView.bringToFront()
+        cameraModeToggleView.bringToFront()
     }
 
     fun onCreate(savedInstanceState: android.os.Bundle?) {
@@ -215,24 +201,16 @@ class KidNativeMapController(
         currentLocation = location
         if (mission == null) {
             lastAppliedBearingDegrees = null
-            lastOrientationCommitAtMillis = 0L
             displayedMissionId = null
             displayedRouteStart = null
             displayedStyleKey = null
-            previousCourseLocation = null
-            currentCourseBearingDegrees = null
         } else if (missionChanged || displayedMissionId != mission.missionId || displayedRouteStart == null) {
             lastAppliedBearingDegrees = null
-            lastOrientationCommitAtMillis = 0L
             displayedMissionId = mission.missionId
             displayedRouteStart = resolveDisplayRouteStart(mission)
-            previousCourseLocation = null
-            currentCourseBearingDegrees = null
-            lastZoneFitUsedStrict = true
         }
         mapContainer.visibility = if (mission != null) View.VISIBLE else View.GONE
         sourceIndicatorView.visibility = if (mission != null) View.VISIBLE else View.GONE
-        cameraModeToggleView?.visibility = if (mission != null) View.VISIBLE else View.GONE
         if (missionChanged || mission == null) {
             applyStyleForMission(mapLibreMap ?: return, mission)
         } else {
@@ -244,87 +222,20 @@ class KidNativeMapController(
     }
 
     fun updateLocation(location: Location?) {
-        updateCourseBearing(location)
         currentLocation = location
         Log.d(
             CAMERA_LOG_TAG,
             "updateLocation raw=${location?.latitude},${location?.longitude} accuracy=${location?.accuracy} bearing=${location?.bearing}",
         )
         updateMissionOverlays()
-        checkArrival()
-
-        if (cameraMode == KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP) {
-            applyFollowCamera(location)
-        } else {
-            applyOrientationBearing()
-            val map = mapLibreMap ?: return
-            val mission = currentMission ?: return
-            refitZoomForCurrentBearing(map, mission)
-        }
-    }
-
-    private fun checkArrival() {
-        val location = currentLocation ?: return
-        val mission = currentMission ?: return
-        val player = LatLng(location.latitude, location.longitude)
-        val target = LatLng(mission.target.latitude, mission.target.longitude)
-        val distance = distanceMeters(player, target)
-        val hasArrived = distance <= 5.0
-        if (hasArrived && !isArrivalShowing) {
-            isArrivalShowing = true
-            arrivalImageView.visibility = View.VISIBLE
-            arrivalImageView.bringToFront()
-        } else if (!hasArrived && isArrivalShowing) {
-            isArrivalShowing = false
-            arrivalImageView.visibility = View.GONE
-        }
-    }
-
-    private fun applyFollowCamera(location: Location?) {
-        val map = mapLibreMap ?: return
-        if (isCameraAnimating) return
-        if (location == null) return
-
-        val plan = cameraPlanner.plan(
-            mode = KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP,
-            location = KidMapCameraPlanner.LocationSnapshot(
-                latitude = location.latitude,
-                longitude = location.longitude,
-                accuracyMeters = location.accuracy,
-            ),
-            headingDegrees = currentHeadingDegrees?.toDouble(),
-            mission = currentMission,
-            viewport = KidMapCameraPlanner.Viewport(
-                widthPx = mapContainer.width.coerceAtLeast(1),
-                heightPx = mapContainer.height.coerceAtLeast(1),
-                topPaddingPx = ((viewportTopInsetPx ?: (mapContainer.height * 0.37f)) + (mapContainer.height * 0.02f)).toInt(),
-                bottomPaddingPx = ((viewportBottomInsetPx ?: (mapContainer.height * 0.14f)) + (mapContainer.height * 0.04f)).toInt(),
-                sidePaddingPx = (mapContainer.width * 0.10f).toInt().coerceAtLeast(40),
-            ),
-        )
-
-        isCameraAnimating = true
-        val cameraUpdate = CameraUpdateFactory.newCameraPosition(
-            CameraPosition.Builder()
-                .target(LatLng(plan.target.latitude, plan.target.longitude))
-                .bearing(plan.bearing)
-                .zoom(plan.zoom)
-                .tilt(plan.tilt)
-                .build(),
-        )
-        map.animateCamera(cameraUpdate, 150, object : MapLibreMap.CancelableCallback {
-            override fun onCancel() {
-                isCameraAnimating = false
-            }
-            override fun onFinish() {
-                isCameraAnimating = false
-            }
-        })
+        updateCameraFromPlan(animate = true)
     }
 
     fun updateHeading(headingDegrees: Float?) {
         currentHeadingDegrees = headingDegrees
-        applyOrientationBearing()
+        if (currentCameraMode == CameraMode.FOLLOW_HEADING_UP) {
+            updateCameraFromPlan(animate = true)
+        }
     }
 
     fun updateNavigationSource(locationSource: String, headingSource: String) {
@@ -422,7 +333,7 @@ class KidNativeMapController(
     fun getLastCameraDebugInfo(): CameraDebugInfo? = lastCameraDebugInfo
 
     fun getCurrentMapBearingDegrees(): Double? =
-        mapLibreMap?.cameraPosition?.bearing?.let { normalizeDegrees(it) } ?: lastAppliedBearingDegrees
+        mapLibreMap?.cameraPosition?.bearing?.let { cameraPlanner.normalizeDegrees(it) } ?: lastAppliedBearingDegrees
 
     fun getCurrentTargetBearingDegrees(): Double? = currentMission?.let { routeBearingForMission(it) }
 
@@ -431,102 +342,127 @@ class KidNativeMapController(
         viewportBottomInsetPx = bottomInsetPx
     }
 
-    private fun updateCamera(animate: Boolean = false) {
-        val map = mapLibreMap ?: return
-        if (!mapStyleLoaded) {
-            Log.d(CAMERA_LOG_TAG, "updateCamera skipped mapStyleLoaded=false")
-            return
+    fun toggleCameraMode() {
+        currentCameraMode = when (currentCameraMode) {
+            CameraMode.ROUTE_OVERVIEW -> CameraMode.FOLLOW_HEADING_UP
+            CameraMode.FOLLOW_HEADING_UP -> CameraMode.ROUTE_OVERVIEW
         }
+        cameraModeToggleView.text = when (currentCameraMode) {
+            CameraMode.ROUTE_OVERVIEW -> "O"
+            CameraMode.FOLLOW_HEADING_UP -> "F"
+        }
+        Log.d(CAMERA_LOG_TAG, "toggleCameraMode -> $currentCameraMode")
+        updateCameraFromPlan(animate = true)
+    }
 
+    private fun updateCamera(animate: Boolean = false) {
+        updateCameraFromPlan(animate)
+    }
+
+    private fun currentViewport(): Viewport {
         val width = mapContainer.width
         val height = mapContainer.height
-        var availableMapHeightPx = 0
-        if (width > 0 && height > 0) {
-            val topPadding = (viewportTopInsetPx ?: (height * 0.37f)).toInt()
-            val sidePadding = (width * 0.08f).toInt()
-            val bottomPadding = (viewportBottomInsetPx ?: (height * 0.14f)).toInt()
-            map.setPadding(sidePadding, topPadding, sidePadding, bottomPadding)
-            availableMapHeightPx = (height - topPadding - bottomPadding).coerceAtLeast(1)
-        }
-
-        val mission = currentMission ?: return
-        val missionTarget = LatLng(mission.target.latitude, mission.target.longitude)
-        val fallbackRouteStart = displayedRouteStart ?: resolveDisplayRouteStart(mission).also {
-            displayedRouteStart = it
-        }
-        val activeRoute = resolveActiveRouteState(mission, fallbackRouteStart)
-        val routeStart = activeRoute.routeStart
-        val routePoints = buildList {
-            add(routeStart)
-            activeRoute.remainingWaypoints.forEach { waypoint ->
-                add(LatLng(waypoint.latitude, waypoint.longitude))
-            }
-            add(missionTarget)
-        }
-        Log.d(
-            CAMERA_LOG_TAG,
-            "updateCamera mission=${mission.missionId} animate=$animate routeStart=${routeStart.latitude},${routeStart.longitude} target=${missionTarget.latitude},${missionTarget.longitude} routePoints=${routePoints.size}",
+        val topPadding = (viewportTopInsetPx ?: (height * 0.37f)).toInt()
+        val bottomPadding = (viewportBottomInsetPx ?: (height * 0.14f)).toInt()
+        val sidePadding = (width * 0.08f).toInt()
+        return Viewport(
+            widthPx = width,
+            heightPx = height,
+            topPaddingPx = topPadding,
+            bottomPaddingPx = bottomPadding,
+            leftPaddingPx = sidePadding,
+            rightPaddingPx = sidePadding,
         )
-        val useFallback = !looksLikeCentralEurope(missionTarget)
-        val cameraTarget = if (useFallback) germanyFallback else missionTarget
-        lastCameraDebugInfo = CameraDebugInfo(
-            latitude = cameraTarget.latitude,
-            longitude = cameraTarget.longitude,
-            usedFallback = useFallback,
-            missionTargetLatitude = missionTarget.latitude,
-            missionTargetLongitude = missionTarget.longitude,
-        )
-        val routeBounds = buildRouteBounds(routePoints)
-        if (routeBounds != null && width > 0 && height > 0) {
-            val sidePadding = (width * 0.10f).toInt().coerceAtLeast(40)
-            val topPadding = ((viewportTopInsetPx ?: (height * 0.37f)) + (height * 0.02f)).toInt()
-            val bottomPadding = ((viewportBottomInsetPx ?: (height * 0.14f)) + (height * 0.04f)).toInt()
-            Log.d(
-                CAMERA_LOG_TAG,
-                "updateCamera routeBounds points=${routePoints.size} top=$topPadding bottom=$bottomPadding side=$sidePadding mode=$cameraMode",
-            )
+    }
 
-            if (cameraMode == KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP) {
-                val location = currentLocation
-                if (location != null) {
-                    applyFollowCamera(location)
-                    return
-                }
-            }
-
-            val update = CameraUpdateFactory.newLatLngBounds(
-                routeBounds,
-                sidePadding,
-                topPadding,
-                sidePadding,
-                bottomPadding,
-            )
-            map.moveCamera(update)
-            maximizeZoomForVisibleEndpoints(
-                map = map,
-                routePoints = routePoints,
-                width = width,
-                height = height,
-                topPadding = topPadding,
-                bottomPadding = bottomPadding,
-                sidePadding = sidePadding,
-            )
-            applyOrientationBearing()
+    private fun updateCameraFromPlan(animate: Boolean = true) {
+        val map = mapLibreMap ?: return
+        if (!mapStyleLoaded) {
+            Log.d(CAMERA_LOG_TAG, "updateCameraFromPlan skipped mapStyleLoaded=false")
             return
         }
 
-        val fallbackCamera = CameraPosition.Builder()
-            .target(cameraTarget)
-            .zoom(16.2)
-            .tilt(20.0)
-            .build()
+        val mission = currentMission
+        if (mission == null) {
+            Log.d(CAMERA_LOG_TAG, "updateCameraFromPlan skipped no mission")
+            return
+        }
+
+        val location = currentLocation?.let { LocationSnapshot(it.latitude, it.longitude) }
+        val heading = currentHeadingDegrees?.toDouble()
+        val viewport = currentViewport()
+
+        val plan = cameraPlanner.plan(currentCameraMode, location, heading, mission, viewport)
+
+        // Respektiere Auto-Switch aus dem Planner (z.B. Follow → Overview bei großer Distanz)
+        if (plan.mode != currentCameraMode) {
+            currentCameraMode = plan.mode
+            cameraModeToggleView.text = when (plan.mode) {
+                CameraMode.ROUTE_OVERVIEW -> "O"
+                CameraMode.FOLLOW_HEADING_UP -> "F"
+            }
+            Log.d(CAMERA_LOG_TAG, "Planner auto-switched to ${plan.mode}")
+        }
+
+        val update = when {
+            plan.bounds != null -> {
+                map.setPadding(
+                    viewport.leftPaddingPx,
+                    viewport.topPaddingPx,
+                    viewport.rightPaddingPx,
+                    viewport.bottomPaddingPx,
+                )
+                CameraUpdateFactory.newLatLngBounds(
+                    plan.bounds,
+                    viewport.leftPaddingPx,
+                    viewport.topPaddingPx,
+                    viewport.rightPaddingPx,
+                    viewport.bottomPaddingPx,
+                )
+            }
+            plan.target != null && plan.zoom != null -> {
+                map.setPadding(0, 0, 0, 0)
+                CameraUpdateFactory.newCameraPosition(
+                    CameraPosition.Builder()
+                        .target(plan.target)
+                        .zoom(plan.zoom)
+                        .bearing(plan.bearing)
+                        .tilt(plan.tilt)
+                        .build()
+                )
+            }
+            else -> {
+                Log.d(CAMERA_LOG_TAG, "updateCameraFromPlan empty plan")
+                return
+            }
+        }
+
         Log.d(
             CAMERA_LOG_TAG,
-            "updateCamera fallback bearing=${fallbackCamera.bearing} zoom=${fallbackCamera.zoom} target=${fallbackCamera.target?.latitude},${fallbackCamera.target?.longitude}",
+            "updateCameraFromPlan mode=${plan.mode} bearing=${plan.bearing} zoom=${plan.zoom} animate=$animate",
         )
-        val update = CameraUpdateFactory.newCameraPosition(fallbackCamera)
-        map.moveCamera(update)
-        applyOrientationBearing()
+
+        if (animate) {
+            map.animateCamera(update)
+        } else {
+            map.moveCamera(update)
+        }
+        logScreenPositions()
+
+        lastAppliedBearingDegrees = plan.bearing
+    }
+
+    private fun logScreenPositions() {
+        val map = mapLibreMap ?: return
+        val mission = currentMission ?: return
+        val playerLatLng = resolveDisplayRouteStart(mission)
+        val targetLatLng = LatLng(mission.target.latitude, mission.target.longitude)
+        val playerScreen = map.projection.toScreenLocation(playerLatLng)
+        val targetScreen = map.projection.toScreenLocation(targetLatLng)
+        Log.d(
+            CAMERA_LOG_TAG,
+            "screen player=${playerScreen.x},${playerScreen.y} target=${targetScreen.x},${targetScreen.y} width=${mapContainer.width} height=${mapContainer.height}",
+        )
     }
 
     private fun updateMissionOverlays() {
@@ -837,7 +773,7 @@ class KidNativeMapController(
         if (!looksLikeCentralEurope(routeStart) || !looksLikeCentralEurope(missionTarget)) {
             return null
         }
-        return bearingBetween(routeStart, missionTarget)
+        return cameraPlanner.bearingBetween(routeStart, missionTarget)
     }
 
     private fun resolveDisplayRouteStart(mission: ActiveMission): LatLng {
@@ -912,458 +848,6 @@ class KidNativeMapController(
         )
     }
 
-    private fun applyOrientationBearing() {
-        val map = mapLibreMap ?: return
-        val mission = currentMission ?: return
-        val desiredBearing = resolveNavigationBearing(mission) ?: return
-        val currentCamera = map.cameraPosition
-        val currentBearing = normalizeDegrees(currentCamera.bearing)
-        val normalizedDesired = normalizeDegrees(desiredBearing)
-        val delta = smallestAngleDifference(currentBearing, normalizedDesired)
-        val now = SystemClock.elapsedRealtime()
-        val elapsedSinceCommit = now - lastOrientationCommitAtMillis
-        if (kotlin.math.abs(delta) < 4.5) {
-            lastAppliedBearingDegrees = currentBearing
-            return
-        }
-        if (elapsedSinceCommit < 320L && kotlin.math.abs(delta) < 12.0) {
-            return
-        }
-        val updatedCamera = CameraPosition.Builder(currentCamera)
-            .bearing(normalizedDesired)
-            .build()
-        map.moveCamera(CameraUpdateFactory.newCameraPosition(updatedCamera))
-        lastAppliedBearingDegrees = normalizedDesired
-        lastOrientationCommitAtMillis = now
-        if (cameraMode != KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP) {
-            refitZoomForCurrentBearing(map, mission)
-        }
-    }
-
-    private fun resolveNavigationBearing(mission: ActiveMission): Double? {
-        val headingBearing = currentHeadingDegrees
-            ?.takeIf { it.isFinite() }
-            ?.toDouble()
-            ?.let(::normalizeDegrees)
-        if (headingBearing != null) {
-            return headingBearing
-        }
-
-        val courseBearing = currentCourseBearingDegrees?.let(::normalizeDegrees)
-        if (courseBearing != null) {
-            return courseBearing
-        }
-
-        return routeBearingForMission(mission)?.let(::normalizeDegrees)
-    }
-
-    private fun updateCourseBearing(location: Location?) {
-        if (location == null) {
-            return
-        }
-        val previous = previousCourseLocation
-        previousCourseLocation = location
-        if (previous == null) {
-            return
-        }
-        val previousLatLng = LatLng(previous.latitude, previous.longitude)
-        val currentLatLng = LatLng(location.latitude, location.longitude)
-        if (distanceMeters(previousLatLng, currentLatLng) < 8.0) {
-            return
-        }
-        currentCourseBearingDegrees = bearingBetween(previousLatLng, currentLatLng)
-    }
-
-    private fun smallestAngleDifference(from: Double, to: Double): Double {
-        var delta = (to - from) % 360.0
-        if (delta > 180.0) delta -= 360.0
-        if (delta < -180.0) delta += 360.0
-        return delta
-    }
-
-    private fun maximizeZoomForVisibleEndpoints(
-        map: MapLibreMap,
-        routePoints: List<LatLng>,
-        width: Int,
-        height: Int,
-        topPadding: Int,
-        bottomPadding: Int,
-        sidePadding: Int,
-    ) {
-        val left = sidePadding.toFloat()
-        val top = topPadding.toFloat()
-        val right = (width - sidePadding).toFloat()
-        val bottom = (height - bottomPadding).toFloat()
-        val safetyInset = 12f
-
-        repeat(14) {
-            val currentCamera = map.cameraPosition
-            val candidateZoom = (currentCamera.zoom + 0.30).coerceAtMost(19.2)
-            if (candidateZoom <= currentCamera.zoom + 0.01) {
-                return
-            }
-
-            val candidateCamera = CameraPosition.Builder(currentCamera)
-                .zoom(candidateZoom)
-                .build()
-            map.moveCamera(CameraUpdateFactory.newCameraPosition(candidateCamera))
-
-            val fits = routePoints.all { point ->
-                val screenPoint = map.projection.toScreenLocation(point)
-                screenPoint.x >= left + safetyInset &&
-                    screenPoint.x <= right - safetyInset &&
-                    screenPoint.y >= top + safetyInset &&
-                    screenPoint.y <= bottom - safetyInset
-            }
-
-            if (!fits) {
-                map.moveCamera(CameraUpdateFactory.newCameraPosition(currentCamera))
-                return
-            }
-        }
-    }
-
-    private fun refitZoomForCurrentBearing(
-        map: MapLibreMap,
-        mission: ActiveMission,
-    ) {
-        val width = mapContainer.width
-        val height = mapContainer.height
-        if (width <= 0 || height <= 0) {
-            return
-        }
-
-        val routeStart = displayedRouteStart ?: resolveDisplayRouteStart(mission).also {
-            displayedRouteStart = it
-        }
-        val missionTarget = LatLng(mission.target.latitude, mission.target.longitude)
-        val activeRoute = resolveActiveRouteState(mission, routeStart)
-        val livePlayer = activeRoute.playerPoint
-        val activeRoutePoints = buildList {
-            add(activeRoute.routeStart)
-            activeRoute.remainingWaypoints.forEach { waypoint ->
-                add(LatLng(waypoint.latitude, waypoint.longitude))
-            }
-            add(missionTarget)
-        }
-        val sidePadding = (width * 0.10f).toInt().coerceAtLeast(40)
-        val topPadding = ((viewportTopInsetPx ?: (height * 0.37f)) + (height * 0.02f)).toInt()
-        val bottomPadding = ((viewportBottomInsetPx ?: (height * 0.14f)) + (height * 0.04f)).toInt()
-        solveRouteCameraForCurrentBearing(
-            map = map,
-            routeStart = livePlayer,
-            missionTarget = missionTarget,
-            activeRoutePoints = activeRoutePoints,
-            width = width,
-            height = height,
-            topPadding = topPadding,
-            bottomPadding = bottomPadding,
-            sidePadding = sidePadding,
-        )
-    }
-
-    private fun solveRouteCameraForCurrentBearing(
-        map: MapLibreMap,
-        routeStart: LatLng,
-        missionTarget: LatLng,
-        activeRoutePoints: List<LatLng>,
-        width: Int,
-        height: Int,
-        topPadding: Int,
-        bottomPadding: Int,
-        sidePadding: Int,
-    ) {
-        if (activeRoutePoints.size < 2) return
-        val availableHeight = (height - topPadding - bottomPadding).coerceAtLeast(1)
-        val targetZoneMaxY = topPadding + (availableHeight * 0.10f)
-        val originZoneMinY = height - bottomPadding - 14f
-        val left = sidePadding.toFloat()
-        val top = topPadding.toFloat()
-        val right = (width - sidePadding).toFloat()
-        val bottom = (height - bottomPadding).toFloat()
-        val safetyInset = 12f
-        val anchorX = (left + right) / 2f
-        val anchorY = (top + bottom) / 2f
-        val previousCamera = map.cameraPosition
-        val routeCenter = computeRouteCenter(activeRoutePoints)
-        val baseCamera = CameraPosition.Builder(map.cameraPosition)
-            .target(routeCenter)
-            .build()
-        map.moveCamera(CameraUpdateFactory.newCameraPosition(baseCamera))
-
-        val strictCamera = maximizeCameraUnderConstraints(
-            map = map,
-            baseCamera = baseCamera,
-            routeStart = routeStart,
-            missionTarget = missionTarget,
-            activeRoutePoints = activeRoutePoints,
-            left = left,
-            top = top,
-            right = right,
-            bottom = bottom,
-            safetyInset = safetyInset,
-            originZoneMinY = originZoneMinY,
-            targetZoneMaxY = targetZoneMaxY,
-            desiredCenterX = width / 2f,
-            desiredCenterY = anchorY,
-            anchorX = anchorX,
-            anchorY = anchorY,
-            requireZones = true,
-            zoneTolerancePx = if (lastZoneFitUsedStrict) 40f else -28f,
-        )
-        val currentCameraVisible = cameraSatisfiesConstraints(
-            map = map,
-            candidate = previousCamera,
-            routeStart = routeStart,
-            missionTarget = missionTarget,
-            activeRoutePoints = activeRoutePoints,
-            left = left,
-            top = top,
-            right = right,
-            bottom = bottom,
-            safetyInset = safetyInset,
-            originZoneMinY = originZoneMinY,
-            targetZoneMaxY = targetZoneMaxY,
-            requireZones = false,
-            zoneTolerancePx = 0f,
-        )
-        val visibilityCamera = maximizeCameraUnderConstraints(
-            map = map,
-            baseCamera = baseCamera,
-            routeStart = routeStart,
-            missionTarget = missionTarget,
-            activeRoutePoints = activeRoutePoints,
-            left = left,
-            top = top,
-            right = right,
-            bottom = bottom,
-            safetyInset = safetyInset,
-            originZoneMinY = originZoneMinY,
-            targetZoneMaxY = targetZoneMaxY,
-            desiredCenterX = width / 2f,
-            desiredCenterY = anchorY,
-            anchorX = anchorX,
-            anchorY = anchorY,
-            requireZones = false,
-            zoneTolerancePx = 0f,
-            minZoom = if (currentCameraVisible) {
-                previousCamera.zoom.coerceIn(8.5, 19.2)
-            } else {
-                8.5
-            },
-            maxZoom = if (currentCameraVisible) {
-                19.2
-            } else {
-                previousCamera.zoom.coerceIn(8.5, 19.2)
-            },
-        )
-        val finalCamera = strictCamera ?: visibilityCamera ?: previousCamera ?: baseCamera
-        lastZoneFitUsedStrict = strictCamera != null
-        map.moveCamera(CameraUpdateFactory.newCameraPosition(finalCamera))
-
-        val finalOrigin = map.projection.toScreenLocation(routeStart)
-        val finalTarget = map.projection.toScreenLocation(missionTarget)
-        Log.d(
-            CAMERA_LOG_TAG,
-            "zone-fit originY=${finalOrigin.y} targetY=${finalTarget.y} originMinY=$originZoneMinY targetMaxY=$targetZoneMaxY top=$topPadding bottom=$bottomPadding height=$height zoom=${map.cameraPosition.zoom} bearing=${map.cameraPosition.bearing}",
-        )
-    }
-
-    private fun maximizeCameraUnderConstraints(
-        map: MapLibreMap,
-        baseCamera: CameraPosition,
-        routeStart: LatLng,
-        missionTarget: LatLng,
-        activeRoutePoints: List<LatLng>,
-        left: Float,
-        top: Float,
-        right: Float,
-        bottom: Float,
-        safetyInset: Float,
-        originZoneMinY: Float,
-        targetZoneMaxY: Float,
-        desiredCenterX: Float,
-        desiredCenterY: Float,
-        anchorX: Float,
-        anchorY: Float,
-        requireZones: Boolean,
-        zoneTolerancePx: Float,
-        minZoom: Double = 8.5,
-        maxZoom: Double = 19.2,
-    ): CameraPosition? {
-        var low = minZoom.coerceIn(8.5, 19.2)
-        var high = maxZoom
-        var bestCamera: CameraPosition? = null
-
-        if (high < low) {
-            return null
-        }
-
-        repeat(18) {
-            val candidateZoom = (low + high) / 2.0
-            val candidate = buildConstrainedCamera(
-                map = map,
-                baseCamera = baseCamera,
-                zoom = candidateZoom,
-                routeStart = routeStart,
-                missionTarget = missionTarget,
-                originZoneMinY = originZoneMinY,
-                targetZoneMaxY = targetZoneMaxY,
-                desiredCenterX = desiredCenterX,
-                desiredCenterY = desiredCenterY,
-                anchorX = anchorX,
-                anchorY = anchorY,
-                requireZones = requireZones,
-            )
-            val candidateValid = cameraSatisfiesConstraints(
-                map = map,
-                candidate = candidate,
-                routeStart = routeStart,
-                missionTarget = missionTarget,
-                activeRoutePoints = activeRoutePoints,
-                left = left,
-                top = top,
-                right = right,
-                bottom = bottom,
-                safetyInset = safetyInset,
-                originZoneMinY = originZoneMinY,
-                targetZoneMaxY = targetZoneMaxY,
-                requireZones = requireZones,
-                zoneTolerancePx = zoneTolerancePx,
-            )
-
-            if (candidateValid) {
-                bestCamera = candidate
-                low = candidateZoom
-            } else {
-                high = candidateZoom
-            }
-        }
-
-        return bestCamera
-    }
-
-    private fun cameraSatisfiesConstraints(
-        map: MapLibreMap,
-        candidate: CameraPosition,
-        routeStart: LatLng,
-        missionTarget: LatLng,
-        activeRoutePoints: List<LatLng>,
-        left: Float,
-        top: Float,
-        right: Float,
-        bottom: Float,
-        safetyInset: Float,
-        originZoneMinY: Float,
-        targetZoneMaxY: Float,
-        requireZones: Boolean,
-        zoneTolerancePx: Float,
-    ): Boolean {
-        map.moveCamera(CameraUpdateFactory.newCameraPosition(candidate))
-
-        val originPoint = map.projection.toScreenLocation(routeStart)
-        val targetPoint = map.projection.toScreenLocation(missionTarget)
-        val routeVisible = activeRoutePoints.all { point ->
-            val screenPoint = map.projection.toScreenLocation(point)
-            screenPoint.x >= left + safetyInset &&
-                screenPoint.x <= right - safetyInset &&
-                screenPoint.y >= top + safetyInset &&
-                screenPoint.y <= bottom - safetyInset
-        }
-        val endpointsVisible =
-            originPoint.x >= left + safetyInset &&
-                originPoint.x <= right - safetyInset &&
-                originPoint.y >= top + safetyInset &&
-                originPoint.y <= bottom - safetyInset &&
-                targetPoint.x >= left + safetyInset &&
-                targetPoint.x <= right - safetyInset &&
-                targetPoint.y >= top + safetyInset &&
-                targetPoint.y <= bottom - safetyInset
-        val endpointsInZones =
-            originPoint.y >= originZoneMinY - zoneTolerancePx &&
-                targetPoint.y <= targetZoneMaxY + zoneTolerancePx
-        return routeVisible && endpointsVisible && (!requireZones || endpointsInZones)
-    }
-
-    private fun buildConstrainedCamera(
-        map: MapLibreMap,
-        baseCamera: CameraPosition,
-        zoom: Double,
-        routeStart: LatLng,
-        missionTarget: LatLng,
-        originZoneMinY: Float,
-        targetZoneMaxY: Float,
-        desiredCenterX: Float,
-        desiredCenterY: Float,
-        anchorX: Float,
-        anchorY: Float,
-        requireZones: Boolean,
-    ): CameraPosition {
-        val zoomCamera = CameraPosition.Builder(baseCamera)
-            .zoom(zoom)
-            .build()
-        map.moveCamera(CameraUpdateFactory.newCameraPosition(zoomCamera))
-
-        val originPoint = map.projection.toScreenLocation(routeStart)
-        val targetPoint = map.projection.toScreenLocation(missionTarget)
-        val currentMidX = (originPoint.x + targetPoint.x) / 2f
-        val currentMidY = (originPoint.y + targetPoint.y) / 2f
-        val deltaX = desiredCenterX - currentMidX
-        val deltaY = if (requireZones) {
-            val minDeltaY = originZoneMinY - originPoint.y
-            val maxDeltaY = targetZoneMaxY - targetPoint.y
-            val preferredDeltaY = originZoneMinY - originPoint.y
-            if (minDeltaY <= maxDeltaY) {
-                preferredDeltaY.coerceIn(minDeltaY, maxDeltaY)
-            } else {
-                preferredDeltaY
-            }
-        } else {
-            desiredCenterY - currentMidY
-        }
-        val shiftedTarget = map.projection.fromScreenLocation(
-            PointF(anchorX - deltaX, anchorY - deltaY),
-        )
-        return CameraPosition.Builder(map.cameraPosition)
-            .target(shiftedTarget)
-            .zoom(zoom)
-            .build()
-    }
-
-    private fun computeRouteCenter(points: List<LatLng>): LatLng {
-        val latMin = points.minOf { it.latitude }
-        val latMax = points.maxOf { it.latitude }
-        val lonMin = points.minOf { it.longitude }
-        val lonMax = points.maxOf { it.longitude }
-        return LatLng(
-            (latMin + latMax) / 2.0,
-            (lonMin + lonMax) / 2.0,
-        )
-    }
-
-    private fun bearingBetween(start: LatLng, end: LatLng): Double {
-        val startLat = Math.toRadians(start.latitude)
-        val startLon = Math.toRadians(start.longitude)
-        val endLat = Math.toRadians(end.latitude)
-        val endLon = Math.toRadians(end.longitude)
-        val deltaLon = endLon - startLon
-        val y = kotlin.math.sin(deltaLon) * kotlin.math.cos(endLat)
-        val x = kotlin.math.cos(startLat) * kotlin.math.sin(endLat) -
-            kotlin.math.sin(startLat) * kotlin.math.cos(endLat) * kotlin.math.cos(deltaLon)
-        return (Math.toDegrees(kotlin.math.atan2(y, x)) + 360.0) % 360.0
-    }
-
-    private fun loadBitmapFromAssets(context: Context, path: String): android.graphics.Bitmap? {
-        return runCatching {
-            context.assets.open(path).use { stream ->
-                android.graphics.BitmapFactory.decodeStream(stream)
-            }
-        }.getOrNull()
-    }
-
-    private fun normalizeDegrees(value: Double): Double {
-        return ((value % 360.0) + 360.0) % 360.0
-    }
 
     private fun looksLikeCentralEurope(target: LatLng): Boolean {
         return target.latitude in 47.0..56.5 && target.longitude in 5.0..16.5
@@ -1454,86 +938,4 @@ class KidNativeMapController(
         val playerPoint: LatLng,
         val remainingWaypoints: List<com.cachekid.companion.host.mission.MissionWaypoint>,
     )
-
-    //region Camera mode
-
-    fun setCameraMode(mode: KidMapCameraPlanner.CameraMode) {
-        if (cameraMode == mode) return
-        cameraMode = mode
-        updateCameraModeToggleIcon()
-        updateCamera(animate = true)
-    }
-
-    private fun toggleCameraMode() {
-        val newMode = when (cameraMode) {
-            KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW -> KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP
-            KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP -> KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW
-        }
-        setCameraMode(newMode)
-    }
-
-    private fun updateCameraModeToggleIcon() {
-        val toggle = cameraModeToggleView ?: return
-        val bitmap = when (cameraMode) {
-            KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW -> buildOverviewIconBitmap()
-            KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP -> buildFollowIconBitmap()
-        }
-        toggle.setImageBitmap(bitmap)
-    }
-
-    private fun buildOverviewIconBitmap(): Bitmap {
-        val bitmap = Bitmap.createBitmap(120, 120, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bitmap)
-        val halo = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.WHITE
-            style = Paint.Style.STROKE
-            strokeWidth = 14f
-        }
-        val ink = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.BLACK
-            style = Paint.Style.STROKE
-            strokeWidth = 10f
-        }
-        // Map rectangle
-        canvas.drawRect(24f, 24f, 96f, 96f, halo)
-        canvas.drawRect(24f, 24f, 96f, 96f, ink)
-        // Crosshair
-        canvas.drawLine(60f, 34f, 60f, 86f, ink)
-        canvas.drawLine(34f, 60f, 86f, 60f, ink)
-        return bitmap
-    }
-
-    private fun buildFollowIconBitmap(): Bitmap {
-        val bitmap = Bitmap.createBitmap(120, 120, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(bitmap)
-        val halo = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.WHITE
-            style = Paint.Style.STROKE
-            strokeWidth = 14f
-        }
-        val ink = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.BLACK
-            style = Paint.Style.STROKE
-            strokeWidth = 10f
-        }
-        val fill = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            color = Color.BLACK
-            style = Paint.Style.FILL
-        }
-        // Triangle pointing up
-        val path = Path().apply {
-            moveTo(60f, 20f)
-            lineTo(100f, 100f)
-            lineTo(20f, 100f)
-            close()
-        }
-        canvas.drawPath(path, halo)
-        canvas.drawPath(path, ink)
-        canvas.drawPath(path, fill)
-        // White dot in center
-        canvas.drawCircle(60f, 70f, 14f, Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE })
-        return bitmap
-    }
-
-    //endregion
 }

--- a/app/src/test/java/com/cachekid/companion/kid/KidMapCameraPlannerTest.kt
+++ b/app/src/test/java/com/cachekid/companion/kid/KidMapCameraPlannerTest.kt
@@ -4,153 +4,452 @@ import com.cachekid.companion.host.mission.ActiveMission
 import com.cachekid.companion.host.mission.MissionTarget
 import com.cachekid.companion.host.mission.MissionWaypoint
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.maplibre.android.geometry.LatLng
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.tan
 
 class KidMapCameraPlannerTest {
 
     private val planner = KidMapCameraPlanner()
-    private val viewport = KidMapCameraPlanner.Viewport(
-        widthPx = 1080,
-        heightPx = 2400,
-        topPaddingPx = 800,
-        bottomPaddingPx = 300,
-        sidePaddingPx = 100,
-    )
 
-    private val berlinMission = ActiveMission(
-        missionId = "test",
-        cacheCode = "GC123",
-        sourceTitle = "Test",
-        childTitle = "Test",
-        summary = "Test mission",
-        target = MissionTarget(52.52, 13.405),
-        routeOrigin = MissionTarget(52.51, 13.395),
-        waypoints = listOf(
-            MissionWaypoint(52.515, 13.40, null),
-            MissionWaypoint(52.518, 13.402, null),
-        ),
-    )
-
-    @Test
-    fun `ROUTE_OVERVIEW uses mission target as camera target`() {
-        val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW,
-            location = null,
-            headingDegrees = null,
-            mission = berlinMission,
-            viewport = viewport,
-        )
-        assertEquals(52.52, plan.target.latitude, 0.001)
-        assertEquals(13.405, plan.target.longitude, 0.001)
+    private companion object {
+        const val EARTH_RADIUS_METERS = 6_371_000.0
+        const val EARTH_CIRCUMFERENCE_METERS = 40_075_016.686
+        const val TILE_SIZE_PX = 1024.0
     }
 
     @Test
-    fun `ROUTE_OVERVIEW falls back to route bearing when no heading`() {
-        val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW,
-            location = null,
-            headingDegrees = null,
-            mission = berlinMission,
-            viewport = viewport,
-        )
-        // Bearing from 52.51,13.395 to 52.52,13.405 is roughly NE (~33°)
-        assertEquals(33.0, plan.bearing, 5.0)
-        assertEquals(16.2, plan.zoom, 0.01)
-        assertEquals(20.0, plan.tilt, 0.01)
-    }
-
-    @Test
-    fun `ROUTE_OVERVIEW uses heading when available`() {
-        val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.ROUTE_OVERVIEW,
-            location = null,
-            headingDegrees = 90.0,
-            mission = berlinMission,
-            viewport = viewport,
-        )
-        assertEquals(90.0, plan.bearing, 0.01)
-    }
-
-    @Test
-    fun `FOLLOW_HEADING_UP uses live location as target`() {
-        val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP,
-            location = KidMapCameraPlanner.LocationSnapshot(
-                latitude = 52.515,
-                longitude = 13.400,
-                accuracyMeters = 10f,
+    fun `ROUTE_OVERVIEW uses route bounds containing all points`() {
+        val mission = activeMission(
+            target = MissionTarget(52.53, 13.42),
+            routeOrigin = MissionTarget(52.51, 13.40),
+            waypoints = listOf(
+                MissionWaypoint(52.52, 13.41),
             ),
-            headingDegrees = 45.0,
-            mission = berlinMission,
-            viewport = viewport,
         )
-        assertEquals(52.515, plan.target.latitude, 0.001)
-        assertEquals(13.400, plan.target.longitude, 0.001)
-        assertEquals(45.0, plan.bearing, 0.01)
+        val location = locationSnapshot(52.50, 13.39)
+        val viewport = viewport()
+
+        val plan = planner.plan(
+            CameraMode.ROUTE_OVERVIEW,
+            location,
+            headingDegrees = 45.0,
+            mission,
+            viewport,
+        )
+
+        assertEquals(CameraMode.ROUTE_OVERVIEW, plan.mode)
+        assertNotNull(plan.bounds)
+        assertNull(plan.target)
+        assertNull(plan.zoom)
+
+        val bounds = plan.bounds!!
+        assertEquals(52.53, bounds.latitudeNorth, 0.001)
+        assertEquals(52.51, bounds.latitudeSouth, 0.001)
+        assertEquals(13.42, bounds.longitudeEast, 0.001)
+        assertEquals(13.40, bounds.longitudeWest, 0.001)
+    }
+
+    @Test
+    fun `ROUTE_OVERVIEW bearing is always 0`() {
+        val mission = activeMission(target = MissionTarget(52.52, 13.405))
+        val plan = planner.plan(
+            CameraMode.ROUTE_OVERVIEW,
+            locationSnapshot(52.52, 13.405),
+            headingDegrees = 123.0,
+            mission,
+            viewport(),
+        )
+        assertEquals(0.0, plan.bearing, 0.01)
         assertEquals(0.0, plan.tilt, 0.01)
     }
 
     @Test
+    fun `FOLLOW_HEADING_UP target is not the player position`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val player = locationSnapshot(52.51, 13.40)
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            player,
+            headingDegrees = 90.0,
+            mission,
+            viewport(),
+        )
+
+        assertEquals(CameraMode.FOLLOW_HEADING_UP, plan.mode)
+        assertNotNull(plan.target)
+        assertFalse(
+            "target should not be exactly playerLocation",
+            plan.target!!.latitude == player.latitude && plan.target!!.longitude == player.longitude,
+        )
+    }
+
+    @Test
     fun `FOLLOW_HEADING_UP zoom is dynamic based on distance to target`() {
-        // Player ~650 m from target -> zoom should be relaxed, not locked at 18.0
-        val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP,
-            location = KidMapCameraPlanner.LocationSnapshot(
-                latitude = 52.515,
-                longitude = 13.400,
-                accuracyMeters = 10f,
-            ),
-            headingDegrees = 45.0,
-            mission = berlinMission,
-            viewport = viewport,
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val nearby = locationSnapshot(52.529, 13.419)
+        val far = locationSnapshot(52.40, 13.30)
+
+        val nearbyPlan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            nearby,
+            headingDegrees = 0.0,
+            mission,
+            viewport(),
         )
-        assert(plan.zoom < 18.0) { "zoom ${plan.zoom} should be < 18.0 for ~650 m distance" }
-        assert(plan.zoom >= 14.5) { "zoom ${plan.zoom} should be >= 14.5" }
+        val farPlan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            far,
+            headingDegrees = 90.0, // offset heading to avoid auto-switch to overview
+            mission,
+            viewport(),
+        )
+
+        assertNotNull(nearbyPlan.zoom)
+        assertNotNull(farPlan.zoom)
+        assertTrue("far zoom should be <= nearby zoom (zoomed out)", farPlan.zoom!! <= nearbyPlan.zoom!!)
+        assertTrue("nearby zoom should not exceed max", nearbyPlan.zoom!! <= KidMapCameraPlanner.MAX_FOLLOW_ZOOM)
     }
 
     @Test
-    fun `FOLLOW_HEADING_UP falls back to zero bearing when no heading`() {
+    fun `FOLLOW_HEADING_UP auto-switches to ROUTE_OVERVIEW when far and target aligned with heading`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val far = locationSnapshot(52.40, 13.30)
+        val alignedHeading = planner.bearingBetween(
+            LatLng(far.latitude, far.longitude),
+            LatLng(mission.target.latitude, mission.target.longitude),
+        )
+
         val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP,
-            location = KidMapCameraPlanner.LocationSnapshot(
-                latitude = 52.515,
-                longitude = 13.400,
-                accuracyMeters = 10f,
-            ),
+            CameraMode.FOLLOW_HEADING_UP,
+            far,
+            headingDegrees = alignedHeading,
+            mission,
+            viewport(),
+        )
+
+        assertEquals(CameraMode.ROUTE_OVERVIEW, plan.mode)
+        assertNotNull(plan.bounds)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP stays in FOLLOW when far but target not aligned with heading`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val far = locationSnapshot(52.40, 13.30)
+
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            far,
+            headingDegrees = 90.0, // perpendicular to bearing, headingDiff > 30°
+            mission,
+            viewport(),
+        )
+
+        assertEquals(CameraMode.FOLLOW_HEADING_UP, plan.mode)
+        assertNotNull(plan.target)
+        assertNotNull(plan.zoom)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP zoom respects viewport padding`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val location = locationSnapshot(52.529, 13.419)
+
+        val smallViewport = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            location,
+            headingDegrees = 0.0,
+            mission,
+            viewport(heightPx = 400, topPaddingPx = 200, bottomPaddingPx = 100),
+        )
+        val largeViewport = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            location,
+            headingDegrees = 0.0,
+            mission,
+            viewport(heightPx = 1200, topPaddingPx = 100, bottomPaddingPx = 100),
+        )
+
+        assertTrue(
+            "small visible area should zoom out more",
+            smallViewport.zoom!! <= largeViewport.zoom!!,
+        )
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP at zero distance does not crash`() {
+        val mission = activeMission(target = MissionTarget(52.52, 13.405))
+        val location = locationSnapshot(52.52, 13.405)
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            location,
+            headingDegrees = 0.0,
+            mission,
+            viewport(),
+        )
+        assertNotNull(plan.zoom)
+        assertTrue(plan.zoom!!.isFinite())
+        assertEquals(KidMapCameraPlanner.MAX_FOLLOW_ZOOM, plan.zoom!!, 0.01)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP fallback bearing is target bearing when no heading`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val player = locationSnapshot(52.51, 13.40)
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            player,
             headingDegrees = null,
-            mission = berlinMission,
-            viewport = viewport,
+            mission,
+            viewport(),
         )
-        assertEquals(0.0, plan.bearing, 0.01)
+        val expectedBearing = planner.bearingBetween(
+            LatLng(player.latitude, player.longitude),
+            LatLng(mission.target.latitude, mission.target.longitude),
+        )
+        assertEquals(expectedBearing, plan.bearing, 0.01)
     }
 
     @Test
-    fun `FOLLOW_HEADING_UP falls back to default location when no location`() {
+    fun `FOLLOW_HEADING_UP normal heading places X above O`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val player = locationSnapshot(52.51, 13.40)
+        val heading = planner.bearingBetween(
+            LatLng(player.latitude, player.longitude),
+            LatLng(mission.target.latitude, mission.target.longitude),
+        )
+        val vp = viewport()
         val plan = planner.plan(
-            mode = KidMapCameraPlanner.CameraMode.FOLLOW_HEADING_UP,
+            CameraMode.FOLLOW_HEADING_UP,
+            player,
+            headingDegrees = heading,
+            mission,
+            vp,
+        )
+
+        val (_, oScreenY) = screenPosition(
+            LatLng(player.latitude, player.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+        val (_, xScreenY) = screenPosition(
+            LatLng(mission.target.latitude, mission.target.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+
+        // X soll oberhalb von O sein (kleineres screenY = weiter oben)
+        assertTrue("X should be above O: xY=$xScreenY oY=$oScreenY", xScreenY < oScreenY)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP reverse heading places O above X`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val player = locationSnapshot(52.51, 13.40)
+        val heading = planner.normalizeDegrees(
+            planner.bearingBetween(
+                LatLng(player.latitude, player.longitude),
+                LatLng(mission.target.latitude, mission.target.longitude),
+            ) + 180.0,
+        )
+        val vp = viewport()
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            player,
+            headingDegrees = heading,
+            mission,
+            vp,
+        )
+
+        val (_, oScreenY) = screenPosition(
+            LatLng(player.latitude, player.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+        val (_, xScreenY) = screenPosition(
+            LatLng(mission.target.latitude, mission.target.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+
+        assertTrue("O should be above X in reverse heading: oY=$oScreenY xY=$xScreenY", oScreenY < xScreenY)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP both O and X are within visible lower 2-3`() {
+        val mission = activeMission(target = MissionTarget(52.53, 13.42))
+        val player = locationSnapshot(52.51, 13.40)
+        val vp = viewport()
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            player,
+            headingDegrees = 45.0,
+            mission,
+            vp,
+        )
+
+        val (_, oScreenY) = screenPosition(
+            LatLng(player.latitude, player.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+        val (_, xScreenY) = screenPosition(
+            LatLng(mission.target.latitude, mission.target.longitude),
+            plan.target!!,
+            plan.zoom!!,
+            plan.bearing,
+            vp,
+        )
+
+        val effectiveTop = max(vp.topPaddingPx, vp.heightPx / 3)
+
+        assertTrue("O should be below top invisible zone (y=$oScreenY top=$effectiveTop)", oScreenY >= effectiveTop)
+        assertTrue("X should be below top invisible zone (y=$xScreenY top=$effectiveTop)", xScreenY >= effectiveTop)
+        assertTrue("O should be within screen height", oScreenY <= vp.heightPx)
+        assertTrue("X should be within screen height", xScreenY <= vp.heightPx)
+    }
+
+    @Test
+    fun `FOLLOW_HEADING_UP uses fallback origin when GPS null`() {
+        val mission = activeMission(
+            target = MissionTarget(52.53, 13.42),
+            routeOrigin = MissionTarget(52.51, 13.40),
+        )
+        val vp = viewport()
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
+            location = null,
+            headingDegrees = 0.0,
+            mission,
+            vp,
+        )
+
+        assertNotNull(plan.target)
+        assertNotNull(plan.zoom)
+        // Der Target sollte ein berechneter Offset-Punkt sein, nicht exakt der routeOrigin
+        assertFalse(
+            "target should not be exactly routeOrigin",
+            plan.target!!.latitude == 52.51 && plan.target!!.longitude == 13.40,
+        )
+    }
+
+    @Test
+    fun `plan handles null location and null mission gracefully`() {
+        val plan = planner.plan(
+            CameraMode.FOLLOW_HEADING_UP,
             location = null,
             headingDegrees = null,
-            mission = berlinMission,
-            viewport = viewport,
+            mission = null,
+            viewport(),
         )
-        assertEquals(52.52, plan.target.latitude, 0.001)
-        assertEquals(13.405, plan.target.longitude, 0.001)
+        assertNotNull(plan.target)
+        assertEquals(KidMapCameraPlanner.MIN_FOLLOW_ZOOM, plan.zoom!!, 0.01)
     }
 
     @Test
     fun `normalizeDegrees handles negative values`() {
-        assertEquals(270.0, KidMapCameraPlanner.normalizeDegrees(-90.0), 0.01)
+        assertEquals(270.0, planner.normalizeDegrees(-90.0), 0.01)
     }
 
     @Test
     fun `normalizeDegrees handles values above 360`() {
-        assertEquals(90.0, KidMapCameraPlanner.normalizeDegrees(450.0), 0.01)
+        assertEquals(45.0, planner.normalizeDegrees(405.0), 0.01)
     }
 
     @Test
     fun `bearingBetween computes correct bearing`() {
-        val bearing = KidMapCameraPlanner.bearingBetween(52.51, 13.395, 52.52, 13.405)
-        // Roughly NE
-        assertEquals(33.0, bearing, 5.0)
+        val start = LatLng(52.52, 13.405)
+        val end = LatLng(52.53, 13.42)
+        val bearing = planner.bearingBetween(start, end)
+        assertTrue("bearing should be roughly NE", bearing in 20.0..70.0)
+    }
+
+    // --- helpers ---
+
+    private fun activeMission(
+        target: MissionTarget,
+        routeOrigin: MissionTarget? = null,
+        waypoints: List<MissionWaypoint> = emptyList(),
+    ): ActiveMission = ActiveMission(
+        missionId = "test-mission",
+        cacheCode = "GC12345",
+        sourceTitle = "Test Cache",
+        childTitle = "Test",
+        summary = "Test summary",
+        target = target,
+        routeOrigin = routeOrigin,
+        waypoints = waypoints,
+    )
+
+    private fun locationSnapshot(lat: Double, lon: Double): LocationSnapshot =
+        LocationSnapshot(latitude = lat, longitude = lon)
+
+    private fun viewport(
+        widthPx: Int = 1080,
+        heightPx: Int = 2400,
+        topPaddingPx: Int = 200,
+        bottomPaddingPx: Int = 200,
+        leftPaddingPx: Int = 80,
+        rightPaddingPx: Int = 80,
+    ): Viewport = Viewport(
+        widthPx = widthPx,
+        heightPx = heightPx,
+        topPaddingPx = topPaddingPx,
+        bottomPaddingPx = bottomPaddingPx,
+        leftPaddingPx = leftPaddingPx,
+        rightPaddingPx = rightPaddingPx,
+    )
+
+    private fun latLngToMercator(latLng: LatLng): Pair<Double, Double> {
+        val x = Math.toRadians(latLng.longitude) * EARTH_RADIUS_METERS
+        val y = ln(
+            tan(Math.PI / 4.0 + Math.toRadians(latLng.latitude) / 2.0)
+        ) * EARTH_RADIUS_METERS
+        return x to y
+    }
+
+    private fun screenPosition(
+        point: LatLng,
+        cameraTarget: LatLng,
+        zoom: Double,
+        bearing: Double,
+        viewport: Viewport,
+    ): Pair<Double, Double> {
+        val scale0 = TILE_SIZE_PX / EARTH_CIRCUMFERENCE_METERS
+        val scale = scale0 * 2.0.pow(zoom)
+
+        val pointM = latLngToMercator(point)
+        val targetM = latLngToMercator(cameraTarget)
+
+        val dx = pointM.first - targetM.first
+        val dy = pointM.second - targetM.second
+
+        val angleRad = Math.toRadians(-bearing)
+        val dxR = dx * cos(angleRad) - dy * sin(angleRad)
+        val dyR = dx * sin(angleRad) + dy * cos(angleRad)
+
+        val screenX = viewport.widthPx / 2.0 + dxR * scale
+        val screenY = viewport.heightPx / 2.0 - dyR * scale
+
+        return screenX to screenY
     }
 }

--- a/tools/inject_tests.sh
+++ b/tools/inject_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+TARGET="/sdcard/Android/data/com.cachekid.companion/files/navigation-input-sideload"
+adb shell "rm -f $TARGET/*.json"
+adb shell "rm -rf $TARGET/imported/*"
+
+NOW_MS=$(($(date +%s) * 1000))
+
+for i in 1 2 3 4 5 6; do
+  MS=$((NOW_MS + i - 1))
+  case $i in
+    1) echo '{"latitude": 52.40, "longitude": 13.20, "headingDegrees": 45.0, "capturedAtEpochMillis": '$MS'}' ;;
+    2) echo '{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 0.0, "capturedAtEpochMillis": '$MS'}' ;;
+    3) echo '{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 180.0, "capturedAtEpochMillis": '$MS'}' ;;
+    4) echo '{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 90.0, "capturedAtEpochMillis": '$MS'}' ;;
+    5) echo '{"latitude": 52.505, "longitude": 13.390, "headingDegrees": 30.0, "capturedAtEpochMillis": '$MS'}' ;;
+    6) echo '{"latitude": 52.5199, "longitude": 13.4049, "headingDegrees": 0.0, "capturedAtEpochMillis": '$MS'}' ;;
+  esac | adb shell "cat > $TARGET/test${i}.json"
+done
+
+echo "Tests injected"

--- a/tools/test1_far.json
+++ b/tools/test1_far.json
@@ -1,0 +1,1 @@
+{"latitude": 52.40, "longitude": 13.20, "headingDegrees": 45.0, "capturedAtEpochMillis": 1715592000000}

--- a/tools/test2_near.json
+++ b/tools/test2_near.json
@@ -1,0 +1,1 @@
+{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 0.0, "capturedAtEpochMillis": 1715592001000}

--- a/tools/test3_reverse.json
+++ b/tools/test3_reverse.json
@@ -1,0 +1,1 @@
+{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 180.0, "capturedAtEpochMillis": 1715592002000}

--- a/tools/test4_side.json
+++ b/tools/test4_side.json
@@ -1,0 +1,1 @@
+{"latitude": 52.519, "longitude": 13.404, "headingDegrees": 90.0, "capturedAtEpochMillis": 1715592003000}


### PR DESCRIPTION
- KidMapCameraPlanner: Reiner Kotlin-Planner für ROUTE_OVERVIEW und FOLLOW_HEADING_UP mit rotierter Mercator-Geometrie
- TILE_SIZE_PX = 1024 (empirisch kalibriert für Meebook E-Ink)
- Auto-Switch Follow → Overview bei >5km wenn Target in Blickrichtung
- Controller respektiert plan.mode, keine duplizierte Logik mehr
- Animation wieder aktiviert (animate-Parameter)
- ~400 Zeilen Legacy-Camera-Code entfernt
- 17 Unit-Tests in KidMapCameraPlannerTest.kt

## Summary

- What changed?
- Why now?

## Professional standard

- [ ] Planned and scoped before implementation
- [ ] Keeps the codebase maintainable and scalable
- [ ] Includes necessary refactoring instead of pushing debt forward silently
- [ ] Includes a meaningful automated test case for the changed behavior, or explains why that is not yet practical

## Issue

- Closes #

## Validation

- [ ] `frontend-tests`
- [ ] `android-tests`
- [ ] Added or updated automated tests
- [ ] Manual verification noted where automation is not yet possible

## Architecture

- [ ] Logic kept in testable modules
- [ ] Refactors included where needed to avoid code sprawl
- [ ] Follow-up issues created for intentionally deferred work

## Risk

- User-facing risk:
- Rollback path:
