### PR TITLE
fix(#58): Arrival detection wiederherstellen nach Merge-Regression

### DIFF
--- a/app/src/main/java/com/cachekid/companion/kid/KidMapCameraPlanner.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidMapCameraPlanner.kt
@@ -304,6 +304,20 @@ class KidMapCameraPlanner {
         val diff = kotlin.math.abs(normalizeDegrees(a) - normalizeDegrees(b))
         return if (diff > 180.0) 360.0 - diff else diff
     }
+
+    /**
+     * Prüft, ob der Spieler das Ziel erreicht hat.
+     * Threshold: 15 Meter (konfigurierbar, default aus Issue #58).
+     */
+    fun hasArrived(
+        playerLat: Double,
+        playerLon: Double,
+        targetLat: Double,
+        targetLon: Double,
+        thresholdMeters: Double = 15.0,
+    ): Boolean {
+        return haversineDistance(playerLat, playerLon, targetLat, targetLon) <= thresholdMeters
+    }
 }
 
 data class LocationSnapshot(

--- a/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
+++ b/app/src/main/java/com/cachekid/companion/kid/KidNativeMapController.kt
@@ -94,6 +94,8 @@ class KidNativeMapController(
     private val cameraPlanner = KidMapCameraPlanner()
     private var currentCameraMode: CameraMode = CameraMode.ROUTE_OVERVIEW
     private lateinit var cameraModeToggleView: android.widget.TextView
+    private val arrivalImageView: ImageView
+    private var isArrivalShowing = false
 
     init {
         MapLibre.getInstance(context.applicationContext)
@@ -158,6 +160,19 @@ class KidNativeMapController(
         }
         overlayContainer.addView(cameraModeToggleView)
         cameraModeToggleView.bringToFront()
+
+        // Arrival overlay (cacheClose.png) – fullscreen, hidden by default
+        arrivalImageView = ImageView(context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            visibility = View.GONE
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            setImageBitmap(loadBitmapFromAssets(context, "web/cacheClose.png"))
+        }
+        overlayContainer.addView(arrivalImageView)
+        arrivalImageView.bringToFront()
     }
 
     fun onCreate(savedInstanceState: android.os.Bundle?) {
@@ -228,6 +243,7 @@ class KidNativeMapController(
             "updateLocation raw=${location?.latitude},${location?.longitude} accuracy=${location?.accuracy} bearing=${location?.bearing}",
         )
         updateMissionOverlays()
+        checkArrival()
         updateCameraFromPlan(animate = true)
     }
 
@@ -863,6 +879,33 @@ class KidNativeMapController(
             result,
         )
         return result[0].toDouble()
+    }
+
+    private fun checkArrival() {
+        val location = currentLocation ?: return
+        val mission = currentMission ?: return
+        val hasArrived = cameraPlanner.hasArrived(
+            playerLat = location.latitude,
+            playerLon = location.longitude,
+            targetLat = mission.target.latitude,
+            targetLon = mission.target.longitude,
+        )
+        if (hasArrived && !isArrivalShowing) {
+            isArrivalShowing = true
+            arrivalImageView.visibility = View.VISIBLE
+            arrivalImageView.bringToFront()
+        } else if (!hasArrived && isArrivalShowing) {
+            isArrivalShowing = false
+            arrivalImageView.visibility = View.GONE
+        }
+    }
+
+    private fun loadBitmapFromAssets(context: Context, path: String): Bitmap? {
+        return runCatching {
+            context.assets.open(path).use { stream ->
+                android.graphics.BitmapFactory.decodeStream(stream)
+            }
+        }.getOrNull()
     }
 
     private fun buildMissingOfflineMapStyleJson(): String {

--- a/app/src/test/java/com/cachekid/companion/kid/KidMapCameraPlannerTest.kt
+++ b/app/src/test/java/com/cachekid/companion/kid/KidMapCameraPlannerTest.kt
@@ -353,6 +353,45 @@ class KidMapCameraPlannerTest {
     }
 
     @Test
+    fun `hasArrived returns true when within threshold`() {
+        val targetLat = 52.52
+        val targetLon = 13.405
+        // 10 Meter nördlich des Targets
+        val playerLat = 52.52009
+        val playerLon = 13.405
+
+        assertTrue(
+            planner.hasArrived(playerLat, playerLon, targetLat, targetLon, thresholdMeters = 15.0),
+        )
+    }
+
+    @Test
+    fun `hasArrived returns false when beyond threshold`() {
+        val targetLat = 52.52
+        val targetLon = 13.405
+        // 100 Meter nördlich des Targets
+        val playerLat = 52.5209
+        val playerLon = 13.405
+
+        assertFalse(
+            planner.hasArrived(playerLat, playerLon, targetLat, targetLon, thresholdMeters = 15.0),
+        )
+    }
+
+    @Test
+    fun `hasArrived uses default threshold of 15 meters`() {
+        val targetLat = 52.52
+        val targetLon = 13.405
+        // 12 Meter nördlich — innerhalb von 15m, außerhalb von 5m
+        val playerLat = 52.52011
+        val playerLon = 13.405
+
+        assertTrue(
+            planner.hasArrived(playerLat, playerLon, targetLat, targetLon),
+        )
+    }
+
+    @Test
     fun `plan handles null location and null mission gracefully`() {
         val plan = planner.plan(
             CameraMode.FOLLOW_HEADING_UP,


### PR DESCRIPTION
- hasArrived() in KidMapCameraPlanner extrahiert (testbar, threshold 15m)
- Controller nutzt planner.hasArrived() statt inline-Logik
- Arrival-Overlay (cacheClose.png) zurückgebaut in init + checkArrival()
- 3 Unit-Tests für hasArrived(): within/beyond/default threshold

Fixes Regression aus PR #69 (Camera-Refactoring hat Arrival-Code entfernt) Related to #58

## Summary

- What changed?
- Why now?

## Professional standard

- [ ] Planned and scoped before implementation
- [ ] Keeps the codebase maintainable and scalable
- [ ] Includes necessary refactoring instead of pushing debt forward silently
- [ ] Includes a meaningful automated test case for the changed behavior, or explains why that is not yet practical

## Issue

- Closes #

## Validation

- [ ] `frontend-tests`
- [ ] `android-tests`
- [ ] Added or updated automated tests
- [ ] Manual verification noted where automation is not yet possible

## Architecture

- [ ] Logic kept in testable modules
- [ ] Refactors included where needed to avoid code sprawl
- [ ] Follow-up issues created for intentionally deferred work

## Risk

- User-facing risk:
- Rollback path:
